### PR TITLE
Fix sleep energy restoration and vet payment issues

### DIFF
--- a/src/context/PetContext.tsx
+++ b/src/context/PetContext.tsx
@@ -16,7 +16,7 @@ type PetContextType = {
   bathe: (amount?: number) => void;
   sleep: (duration?: number) => Promise<{ completed: boolean }>;
   cancelSleep: () => void;
-  visitVet: (useMoney?: boolean) => void;
+  visitVet: (useMoney?: boolean) => boolean;
   exercise: () => void;
   petCuddle: () => void;
   setClothing: (slot: ClothingSlot, itemId: string | null) => void;
@@ -180,6 +180,11 @@ export const PetProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
   };
 
   const sleep = async (duration: number = GAME_BALANCE.activities.sleep.duration): Promise<{ completed: boolean }> => {
+    // Check if pet can sleep before starting
+    if (!pet || !canPerformActivity(pet, 'sleep')) {
+      return { completed: false };
+    }
+
     // Create cancellation token
     const cancelToken = { cancelled: false };
     sleepCancelRef.current = cancelToken;
@@ -187,7 +192,7 @@ export const PetProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     const startTime = Date.now();
 
     setPet((currentPet) => {
-      if (!currentPet || !canPerformActivity(currentPet, 'sleep')) return currentPet;
+      if (!currentPet) return currentPet;
 
       const updatedPet: Pet = {
         ...currentPet,
@@ -247,14 +252,18 @@ export const PetProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     }
   };
 
-  const visitVet = (useMoney: boolean = true) => {
+  const visitVet = (useMoney: boolean = true): boolean => {
+    if (!pet) return false;
+
+    const effects = GAME_BALANCE.activities.vet;
+
+    // Check if can afford
+    if (useMoney && pet.money < effects.cost) {
+      return false;
+    }
+
     setPet((currentPet) => {
       if (!currentPet) return currentPet;
-
-      const effects = GAME_BALANCE.activities.vet;
-
-      // Check if can afford
-      if (useMoney && currentPet.money < effects.cost) return currentPet;
 
       const updatedPet: Pet = {
         ...currentPet,
@@ -271,6 +280,8 @@ export const PetProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       savePet(updatedPet).catch(logger.error);
       return updatedPet;
     });
+
+    return true;
   };
 
   const exercise = () => {

--- a/src/screens/VetScene.tsx
+++ b/src/screens/VetScene.tsx
@@ -89,7 +89,18 @@ export const VetScene: React.FC<Props> = ({ navigation }) => {
   };
 
   const performVetVisit = (useMoney: boolean) => {
-    visitVet(useMoney);
+    const success = visitVet(useMoney);
+
+    if (!success) {
+      Alert.alert(
+        'Visit Failed',
+        useMoney
+          ? `You need ${GAME_BALANCE.activities.vet.cost} coins for a vet visit. You have ${pet.money} coins.`
+          : 'Unable to complete vet visit. Please try again.',
+        [{ text: 'OK' }]
+      );
+      return;
+    }
 
     Alert.alert(
       '✅ Checkup Complete!',


### PR DESCRIPTION
Sleep Fix:
- Added early return in sleep() if canPerformActivity fails
- Prevents decay from running during failed sleep attempts
- Ensures isSleeping flag is properly set before waiting

Vet Fix:
- Changed visitVet() return type from void to boolean
- Returns false when payment fails (insufficient funds)
- VetScene now checks return value and shows appropriate error
- Prevents success message from showing when visit fails