### PR TITLE
🎨 Palette: Improved accessibility of Play Scene navigation

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -8,7 +8,10 @@
     "year": "year",
     "years": "years",
     "loading": "Loading...",
-    "or": "OR"
+    "or": "OR",
+    "previous": "Previous",
+    "next": "Next",
+    "of": "of"
   },
   "menu": {
     "title": "🐾 Pet Care",
@@ -104,6 +107,7 @@
   "play": {
     "title": "🎮 Play",
     "chooseActivity": "Choose the activity:",
+    "activity": "Activity",
     "activities": {
       "yarnBall": "Yarn Ball",
       "smallBall": "Small Ball"

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -8,7 +8,10 @@
     "year": "ano",
     "years": "anos",
     "loading": "Carregando...",
-    "or": "OU"
+    "or": "OU",
+    "previous": "Anterior",
+    "next": "Próximo",
+    "of": "de"
   },
   "menu": {
     "title": "🐾 Pet Care",
@@ -105,6 +108,7 @@
   "play": {
     "title": "🎮 Brincar",
     "chooseActivity": "Escolha a atividade:",
+    "activity": "Atividade",
     "activities": {
       "yarnBall": "Novelo de Lã",
       "smallBall": "Bolinha"

--- a/src/screens/PlayScene.tsx
+++ b/src/screens/PlayScene.tsx
@@ -104,6 +104,9 @@ export const PlayScene: React.FC<Props> = ({ navigation }) => {
             ]}
             onPress={goToPrevious}
             disabled={isAnimating}
+            accessibilityRole="button"
+            accessibilityLabel={`${t('common.previous')} ${t('play.activity')}`}
+            accessibilityHint={t('play.chooseActivity')}
           >
             <Text style={[styles.arrowText, { fontSize: buttonSizes.arrowFontSize }]}>←</Text>
           </TouchableOpacity>
@@ -145,12 +148,18 @@ export const PlayScene: React.FC<Props> = ({ navigation }) => {
             ]}
             onPress={goToNext}
             disabled={isAnimating}
+            accessibilityRole="button"
+            accessibilityLabel={`${t('common.next')} ${t('play.activity')}`}
+            accessibilityHint={t('play.chooseActivity')}
           >
             <Text style={[styles.arrowText, { fontSize: buttonSizes.arrowFontSize }]}>→</Text>
           </TouchableOpacity>
         </View>
 
-        <Text style={[styles.pageIndicator, { fontSize: fs(13), marginBottom: spacing(12) }]}>
+        <Text
+          style={[styles.pageIndicator, { fontSize: fs(13), marginBottom: spacing(12) }]}
+          accessibilityLabel={`${currentIndex + 1} ${t('common.of')} ${totalItems}`}
+        >
           {currentIndex + 1} / {totalItems}
         </Text>
       </View>

--- a/src/screens/__tests__/PlayScene.test.tsx
+++ b/src/screens/__tests__/PlayScene.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { PlayScene } from '../PlayScene';
+
+// Mock dependencies
+jest.mock('../../context/PetContext', () => ({
+  usePet: () => ({
+    pet: {
+      id: 'test-pet-id',
+      name: 'Fluffy',
+      type: 'cat',
+      gender: 'female',
+      color: 'base',
+      hunger: 50,
+      hygiene: 50,
+      energy: 50,
+      happiness: 50,
+      health: 100,
+      money: 100,
+      clothes: { head: null, eyes: null, torso: null, paws: null },
+      createdAt: Date.now(),
+      user_id: 'test-user',
+    },
+  }),
+}));
+
+jest.mock('../../hooks/usePetActions', () => ({
+  usePetActions: () => ({
+    animationState: 'idle',
+    message: '',
+    isAnimating: false,
+    performAction: jest.fn(),
+    DoubleRewardModal: null,
+  }),
+}));
+
+jest.mock('../../hooks/useNavigationList', () => ({
+  useNavigationList: () => ({
+    currentItem: { emoji: '🧶', nameKey: 'play.activities.yarnBall' },
+    currentIndex: 0,
+    goToNext: jest.fn(),
+    goToPrevious: jest.fn(),
+    totalItems: 5,
+  }),
+}));
+
+jest.mock('../../hooks/useResponsive', () => ({
+  useResponsive: () => ({
+    deviceType: 'mobile',
+    spacing: (n: number) => n,
+    fs: (n: number) => n,
+  }),
+}));
+
+jest.mock('../../hooks/useBackButton', () => ({
+  useBackButton: () => () => null,
+}));
+
+jest.mock('../../components/StatusCard', () => ({
+  StatusCard: () => null,
+}));
+
+jest.mock('../../components/PetRenderer', () => ({
+  PetRenderer: () => null,
+}));
+
+jest.mock('../../components/ScreenHeader', () => ({
+  ScreenHeader: () => null,
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      // Simple mock for t function to return predictable strings
+      if (key === 'common.previous') return 'Previous';
+      if (key === 'common.next') return 'Next';
+      if (key === 'common.of') return 'of';
+      if (key === 'play.activity') return 'Activity';
+      return key;
+    },
+  }),
+}));
+
+// Mock navigation
+const mockNavigation = {
+  navigate: jest.fn(),
+  goBack: jest.fn(),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as unknown as any;
+
+describe('PlayScene', () => {
+  it('renders with accessible navigation controls', () => {
+    const { getByLabelText } = render(<PlayScene navigation={mockNavigation} />);
+
+    // Check for Previous arrow
+    expect(getByLabelText('Previous Activity')).toBeTruthy();
+
+    // Check for Next arrow
+    expect(getByLabelText('Next Activity')).toBeTruthy();
+
+    // Check for Page Indicator (currentIndex 0 means "1", totalItems 5)
+    expect(getByLabelText('1 of 5')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
🎨 Palette: Improved accessibility of Play Scene navigation

💡 What:
- Added accessible labels to the "Previous" and "Next" activity arrows in the Play Scene.
- Added accessible labels to the page indicator (e.g., "1 of 5").
- Added missing translations for "Previous", "Next", "of", and "Activity".

🎯 Why:
- Screen reader users previously heard "left arrow" or nothing when navigating activities.
- Standardizes the navigation experience with the `FeedScene`.
- Improves the "Micro-UX" for assistive technology users.

♿ Accessibility:
- Arrows now announce "Previous Activity" / "Next Activity".
- Page indicator announces "X of Y".
- Proper button roles assigned.


---
*PR created automatically by Jules for task [15423546049493827885](https://jules.google.com/task/15423546049493827885) started by @az1nn*