### PR TITLE
🎨 Palette: Add loading state to Create Pet button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,7 @@
 ## 2026-05-24 - [Testing Reanimated Components]
 **Learning:** Testing components using `react-native-reanimated` with `react-test-renderer` requires strict environment mocking, specifically `findNodeHandle` in `react-native` mock, or mocking the library entirely to avoid DOM-related errors (like `getBoundingClientRect`).
 **Action:** When adding Reanimated to existing components, update `jest.setup.js` to include `findNodeHandle: jest.fn()` in the `react-native` mock, or wrap the component in a test that mocks `react-native-reanimated` logic.
+
+## 2026-05-25 - [Accessibility State for Loading Buttons]
+**Learning:** Buttons performing async actions need to communicate their state to screen readers. Simply disabling them is insufficient; the `busy` state informs users that processing is occurring.
+**Action:** When adding loading states to buttons, always include `accessibilityState={{ busy: true }}` alongside the visual indicator (like `ActivityIndicator`).

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -39,6 +39,7 @@ jest.mock('react-native', () => {
     TextInput: mockComponent('TextInput'),
     SafeAreaView: mockComponent('SafeAreaView'),
     KeyboardAvoidingView: mockComponent('KeyboardAvoidingView'),
+    ActivityIndicator: mockComponent('ActivityIndicator'),
     useWindowDimensions: jest.fn(() => ({ width: 375, height: 812, scale: 2, fontScale: 2 })),
     PixelRatio: {
       get: jest.fn(() => 2),

--- a/src/screens/CreatePetScreen.tsx
+++ b/src/screens/CreatePetScreen.tsx
@@ -10,6 +10,7 @@ import {
   Platform,
   ViewStyle,
   TextStyle,
+  ActivityIndicator,
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import Animated, {
@@ -100,6 +101,7 @@ export const CreatePetScreen: React.FC<Props> = ({ navigation }) => {
   const [petType, setPetType] = useState<PetType>('cat');
   const [gender, setGender] = useState<Gender>('female');
   const [color, setColor] = useState<PetColor>('base');
+  const [isLoading, setIsLoading] = useState(false);
 
   // Reset color when switching pet type if the color is not available for the new type
   const handlePetTypeChange = (newType: PetType) => {
@@ -118,9 +120,15 @@ export const CreatePetScreen: React.FC<Props> = ({ navigation }) => {
       return;
     }
 
-    const sanitizedName = sanitizePetName(name);
-    await createPet(sanitizedName, petType, gender, color);
-    navigation.replace('Home');
+    try {
+      setIsLoading(true);
+      const sanitizedName = sanitizePetName(name);
+      await createPet(sanitizedName, petType, gender, color);
+      navigation.replace('Home');
+    } catch {
+      setIsLoading(false);
+      showToast(t('createPet.error', { defaultValue: 'Failed to create pet' }), 'error');
+    }
   };
 
   return (
@@ -248,8 +256,12 @@ export const CreatePetScreen: React.FC<Props> = ({ navigation }) => {
         </View>
 
         <TouchableOpacity
-          style={[styles.createButton, !name.trim() && styles.createButtonDisabled]}
+          style={[
+            styles.createButton,
+            (!name.trim() || isLoading) && styles.createButtonDisabled,
+          ]}
           onPress={() => {
+            if (isLoading) return;
             if (!name.trim()) {
               hapticFeedback.light();
               showToast(t('createPet.nameRequired'), 'info');
@@ -257,13 +269,17 @@ export const CreatePetScreen: React.FC<Props> = ({ navigation }) => {
             }
             handleCreate();
           }}
-          activeOpacity={!name.trim() ? 1 : 0.7}
+          activeOpacity={!name.trim() || isLoading ? 1 : 0.7}
           accessibilityRole="button"
           accessibilityLabel={t('createPet.createButton')}
-          accessibilityState={{ disabled: !name.trim() }}
+          accessibilityState={{ disabled: !name.trim() || isLoading, busy: isLoading }}
           accessibilityHint={!name.trim() ? t('createPet.nameRequired') : undefined}
         >
-          <Text style={styles.createButtonText}>{t('createPet.createButton')}</Text>
+          {isLoading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.createButtonText}>{t('createPet.createButton')}</Text>
+          )}
         </TouchableOpacity>
       </KeyboardAvoidingView>
     </SafeAreaView>

--- a/src/screens/__tests__/CreatePetScreen.test.tsx
+++ b/src/screens/__tests__/CreatePetScreen.test.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { CreatePetScreen } from '../CreatePetScreen';
+import { usePet } from '../../context/PetContext';
 
 // Mock dependencies
 jest.mock('../../context/PetContext', () => ({
-  usePet: () => ({
-    createPet: jest.fn(),
-  }),
+  usePet: jest.fn(),
 }));
 
 jest.mock('react-native-reanimated', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const Reanimated = require('react-native-reanimated/mock');
 
   // The mock for `call` immediately calls the callback which is incorrect
@@ -66,6 +66,14 @@ const mockNavigation = {
 } as unknown as any;
 
 describe('CreatePetScreen', () => {
+  const mockCreatePet = jest.fn();
+
+  beforeEach(() => {
+    (usePet as jest.Mock).mockReturnValue({
+      createPet: mockCreatePet,
+    });
+  });
+
   it('renders correctly', () => {
     const { getByText } = render(<CreatePetScreen navigation={mockNavigation} />);
 
@@ -82,5 +90,40 @@ describe('CreatePetScreen', () => {
     // Check if accessibility label is present (initially 0/20, then 6/20)
     // The current implementation uses t('common.of') which mocks to "common.of"
     expect(getByLabelText('6 common.of 20')).toBeTruthy();
+  });
+
+  it('shows loading state during pet creation', async () => {
+    let resolveCreate: (value: void | PromiseLike<void>) => void;
+    const createPromise = new Promise<void>((resolve) => {
+      resolveCreate = resolve;
+    });
+    mockCreatePet.mockReturnValue(createPromise);
+
+    const { getByLabelText, getByPlaceholderText, queryByText } = render(
+      <CreatePetScreen navigation={mockNavigation} />
+    );
+
+    // Enter valid name
+    const input = getByPlaceholderText('createPet.namePlaceholder');
+    fireEvent.changeText(input, 'Fluffy');
+
+    // Find create button
+    const createButton = getByLabelText('createPet.createButton');
+
+    // Press button
+    fireEvent.press(createButton);
+
+    // Verify loading state: Text should be gone (replaced by ActivityIndicator)
+    expect(queryByText('createPet.createButton')).toBeNull();
+
+    // Verify button is disabled/busy via accessibility
+    expect(createButton.props.accessibilityState).toEqual({
+      disabled: true,
+      busy: true,
+    });
+
+    // Resolve promise to clean up
+    resolveCreate!();
+    await waitFor(() => expect(mockCreatePet).toHaveBeenCalled());
   });
 });


### PR DESCRIPTION
Implemented a loading state for the "Create Pet" button to provide visual feedback and prevent multiple submissions.

**UX Improvements:**
- Replaces button text with a spinner during the async creation process.
- Disables the button to prevent accidental double-taps.
- Adds error handling (toast notification) if creation fails.

**Accessibility:**
- Updates `accessibilityState` to include `busy: true` when loading, informing screen reader users of the processing state.

**Testing:**
- Verified with new unit test in `CreatePetScreen.test.tsx`.
- Verified linting passes.

---
*PR created automatically by Jules for task [15482945396504065137](https://jules.google.com/task/15482945396504065137) started by @az1nn*