### PR TITLE
🎨 Palette: Localize navigation accessibility labels

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -8,7 +8,9 @@
     "year": "year",
     "years": "years",
     "loading": "Loading...",
-    "or": "OR"
+    "or": "OR",
+    "previous": "Previous",
+    "next": "Next"
   },
   "menu": {
     "title": "🐾 Pet Care",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -8,7 +8,9 @@
     "year": "ano",
     "years": "anos",
     "loading": "Carregando...",
-    "or": "OU"
+    "or": "OU",
+    "previous": "Anterior",
+    "next": "Próximo"
   },
   "menu": {
     "title": "🐾 Pet Care",

--- a/src/screens/FeedScene.tsx
+++ b/src/screens/FeedScene.tsx
@@ -120,8 +120,7 @@ export const FeedScene: React.FC<Props> = ({ navigation }) => {
             onPress={goToPrevious}
             disabled={isAnimating}
             accessibilityRole="button"
-            accessibilityLabel="Previous food"
-            accessibilityHint="Show previous food option"
+            accessibilityLabel={t('common.previous')}
             accessibilityState={{ disabled: isAnimating }}
           >
             <Text style={[styles.arrowText, { fontSize: buttonSizes.arrowFontSize }]}>←</Text>
@@ -181,8 +180,7 @@ export const FeedScene: React.FC<Props> = ({ navigation }) => {
             onPress={goToNext}
             disabled={isAnimating}
             accessibilityRole="button"
-            accessibilityLabel="Next food"
-            accessibilityHint="Show next food option"
+            accessibilityLabel={t('common.next')}
             accessibilityState={{ disabled: isAnimating }}
           >
             <Text style={[styles.arrowText, { fontSize: buttonSizes.arrowFontSize }]}>→</Text>

--- a/src/screens/PlayScene.tsx
+++ b/src/screens/PlayScene.tsx
@@ -104,6 +104,8 @@ export const PlayScene: React.FC<Props> = ({ navigation }) => {
             ]}
             onPress={goToPrevious}
             disabled={isAnimating}
+            accessibilityRole="button"
+            accessibilityLabel={t('common.previous')}
           >
             <Text style={[styles.arrowText, { fontSize: buttonSizes.arrowFontSize }]}>←</Text>
           </TouchableOpacity>
@@ -145,6 +147,8 @@ export const PlayScene: React.FC<Props> = ({ navigation }) => {
             ]}
             onPress={goToNext}
             disabled={isAnimating}
+            accessibilityRole="button"
+            accessibilityLabel={t('common.next')}
           >
             <Text style={[styles.arrowText, { fontSize: buttonSizes.arrowFontSize }]}>→</Text>
           </TouchableOpacity>


### PR DESCRIPTION
🎨 **Palette: Localize Navigation Accessibility Labels**\n\n**💡 What:**\n- Added localized "Previous" and "Next" labels to `src/locales`.\n- Updated `FeedScene.tsx` to use these localized keys for the food selection arrow buttons.\n- Updated `PlayScene.tsx` to add `accessibilityRole="button"` and localized labels to the activity selection arrow buttons (which previously had no accessibility attributes).\n- Removed hardcoded English `accessibilityHint`s from `FeedScene` to reduce verbosity and mixed-language output for non-English users.\n\n**🎯 Why:**\n- **Accessibility:** Screen reader users relying on Portuguese (or other future languages) were hearing "Previous food" (hardcoded English) or nothing at all (in PlayScene).\n- **Consistency:** Standardizes navigation controls across the app to use the centralized `common` locale namespace.\n\n**♿ Accessibility Improvements:**\n- **PlayScene:** Navigation arrows are now recognized as buttons and have descriptive labels.\n- **FeedScene:** Navigation arrows now respect the user's selected language.\n- **General:** Removed redundant/hardcoded hints that cluttered the experience.\n\n**📸 Verification:**\n- Verified JSON validity of locale files.\n- Verified `FeedScene.tsx` and `PlayScene.tsx` updates.\n- Ran `pnpm test` to ensure no regressions (all pass).

---
*PR created automatically by Jules for task [4392943299581658725](https://jules.google.com/task/4392943299581658725) started by @az1nn*