### PR TITLE
🎨 Palette: Improve accessibility of StatusCard money display

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,7 @@
 ## 2026-05-24 - [Testing Reanimated Components]
 **Learning:** Testing components using `react-native-reanimated` with `react-test-renderer` requires strict environment mocking, specifically `findNodeHandle` in `react-native` mock, or mocking the library entirely to avoid DOM-related errors (like `getBoundingClientRect`).
 **Action:** When adding Reanimated to existing components, update `jest.setup.js` to include `findNodeHandle: jest.fn()` in the `react-native` mock, or wrap the component in a test that mocks `react-native-reanimated` logic.
+
+## 2026-05-25 - [Semantic Grouping for Accessibility]
+**Learning:** Elements that visually form a single unit (like an icon and a value) should be grouped for screen readers. Reading them separately (e.g., "Money Bag" then "100") lacks context and flow.
+**Action:** Wrap related elements in a `View` with `accessible={true}` and provide a unified `accessibilityLabel` (e.g., "100 coins") to create a cohesive audio experience.

--- a/src/components/StatusCard.tsx
+++ b/src/components/StatusCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Pet } from '../types';
 import { EnhancedStatusBar } from './EnhancedStatusBar';
 import { useResponsive } from '../hooks/useResponsive';
@@ -18,6 +19,7 @@ export const StatusCard: React.FC<StatusCardProps> = ({
   petAge,
 }) => {
   const { fs, spacing } = useResponsive();
+  const { t } = useTranslation();
 
   const dynamicStyles = {
     card: {
@@ -55,7 +57,12 @@ export const StatusCard: React.FC<StatusCardProps> = ({
         <View style={styles.leftColumn}>
           <Text style={[styles.petName, dynamicStyles.petName]}>{petName}</Text>
           <Text style={[styles.petAge, dynamicStyles.petAge]}>{petAge}</Text>
-          <View style={[styles.moneyContainer, dynamicStyles.moneyContainer]}>
+          <View
+            style={[styles.moneyContainer, dynamicStyles.moneyContainer]}
+            accessible={true}
+            accessibilityRole="text"
+            accessibilityLabel={t('home.money', { amount: pet.money ?? 0 })}
+          >
             <Text style={[styles.coinIcon, dynamicStyles.coinIcon]}>💰</Text>
             <Text style={[styles.moneyValue, dynamicStyles.moneyValue]}>{pet.money ?? 0}</Text>
           </View>

--- a/src/components/__tests__/StatusCard.test.tsx
+++ b/src/components/__tests__/StatusCard.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { StatusCard } from '../StatusCard';
+import { Pet } from '../../types';
+
+// Mock dependencies
+jest.mock('../../hooks/useResponsive', () => ({
+  useResponsive: () => ({
+    fs: (v: number) => v,
+    spacing: (v: number) => v,
+  }),
+}));
+
+// Mock react-i18next
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: any) => {
+      if (options) {
+        return `${key}:${JSON.stringify(options)}`;
+      }
+      return key;
+    },
+  }),
+}));
+
+// Mock EnhancedStatusBar to simplify testing
+jest.mock('../EnhancedStatusBar', () => ({
+  EnhancedStatusBar: 'EnhancedStatusBar',
+}));
+
+describe('StatusCard', () => {
+  const mockPet: Pet = {
+    id: 'test-pet-id',
+    name: 'Fluffy',
+    type: 'cat',
+    gender: 'female',
+    color: 'base',
+    hunger: 80,
+    hygiene: 80,
+    energy: 80,
+    happiness: 80,
+    health: 100,
+    money: 100,
+    createdAt: Date.now(),
+    lastInteraction: Date.now(),
+    isSleeping: false,
+    statsHistory: [],
+    unlockedItems: [],
+    clothing: {},
+  };
+
+  it('renders pet name and age', () => {
+    const { getByText } = render(
+      <StatusCard
+        pet={mockPet}
+        petName="🐱 Fluffy"
+        petAge="1 year"
+      />
+    );
+    expect(getByText('🐱 Fluffy')).toBeTruthy();
+    expect(getByText('1 year')).toBeTruthy();
+  });
+
+  it('renders money with accessible label', () => {
+    const { getByLabelText } = render(
+      <StatusCard
+        pet={mockPet}
+        petName="🐱 Fluffy"
+        petAge="1 year"
+      />
+    );
+
+    // This should fail initially because the money display is split into two Texts
+    // and doesn't have an accessibilityLabel on the container.
+    // The label we expect after fix is: t('home.money', { amount: 100 })
+    const label = `home.money:${JSON.stringify({ amount: 100 })}`;
+    expect(getByLabelText(label)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
💡 What: Wrapped the money icon and value in a container View with accessible={true}, accessibilityRole="text", and a semantic accessibilityLabel.
🎯 Why: Screen readers were reading the money bag emoji and the value separately, creating a disjointed experience. Grouping them ensures they are announced as "X coins".
♿ Accessibility: Added accessibilityLabel using existing translations to provide semantic context ("100 coins" instead of "Money Bag 100").
Related: Added src/components/__tests__/StatusCard.test.tsx to prevent regressions.

---
*PR created automatically by Jules for task [3583428066540648042](https://jules.google.com/task/3583428066540648042) started by @az1nn*