### PR TITLE
🎨 Palette: StatusCard Accessibility Improvement

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,7 @@
 ## 2026-05-24 - [Testing Reanimated Components]
 **Learning:** Testing components using `react-native-reanimated` with `react-test-renderer` requires strict environment mocking, specifically `findNodeHandle` in `react-native` mock, or mocking the library entirely to avoid DOM-related errors (like `getBoundingClientRect`).
 **Action:** When adding Reanimated to existing components, update `jest.setup.js` to include `findNodeHandle: jest.fn()` in the `react-native` mock, or wrap the component in a test that mocks `react-native-reanimated` logic.
+
+## 2026-05-24 - [Grouping Information for Accessibility]
+**Learning:** Elements that visually group an icon and a text value (e.g., currency displays "💰 100") are read as separate, disconnected items by screen readers ("Money bag", "100") if not grouped.
+**Action:** Wrap related icon and text elements in a container View with `accessible={true}`, `accessibilityRole="text"`, and a comprehensive `accessibilityLabel` (e.g., "100 coins") to provide a coherent experience.

--- a/src/components/StatusCard.tsx
+++ b/src/components/StatusCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Pet } from '../types';
 import { EnhancedStatusBar } from './EnhancedStatusBar';
 import { useResponsive } from '../hooks/useResponsive';
@@ -17,6 +18,7 @@ export const StatusCard: React.FC<StatusCardProps> = ({
   petName,
   petAge,
 }) => {
+  const { t } = useTranslation();
   const { fs, spacing } = useResponsive();
 
   const dynamicStyles = {
@@ -55,7 +57,12 @@ export const StatusCard: React.FC<StatusCardProps> = ({
         <View style={styles.leftColumn}>
           <Text style={[styles.petName, dynamicStyles.petName]}>{petName}</Text>
           <Text style={[styles.petAge, dynamicStyles.petAge]}>{petAge}</Text>
-          <View style={[styles.moneyContainer, dynamicStyles.moneyContainer]}>
+          <View
+            style={[styles.moneyContainer, dynamicStyles.moneyContainer]}
+            accessible={true}
+            accessibilityRole="text"
+            accessibilityLabel={`${pet.money ?? 0} ${t('common.coins')}`}
+          >
             <Text style={[styles.coinIcon, dynamicStyles.coinIcon]}>💰</Text>
             <Text style={[styles.moneyValue, dynamicStyles.moneyValue]}>{pet.money ?? 0}</Text>
           </View>

--- a/src/components/__tests__/StatusCard.test.tsx
+++ b/src/components/__tests__/StatusCard.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { StatusCard } from '../StatusCard';
+import { Pet } from '../../types';
+
+// Mock dependencies
+jest.mock('../../hooks/useResponsive', () => ({
+  useResponsive: () => ({
+    fs: (v: number) => v,
+    spacing: (v: number) => v,
+  }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      if (key === 'common.coins') return 'coins';
+      return key;
+    },
+  }),
+}));
+
+jest.mock('../EnhancedStatusBar', () => ({
+  EnhancedStatusBar: 'EnhancedStatusBar',
+}));
+
+describe('StatusCard', () => {
+  const mockPet: Pet = {
+    id: '1',
+    name: 'Fluffy',
+    type: 'cat',
+    gender: 'female',
+    coatColor: 'white',
+    createdAt: new Date().toISOString(),
+    health: 100,
+    hunger: 100,
+    hygiene: 100,
+    energy: 100,
+    happiness: 100,
+    experience: 0,
+    level: 1,
+    money: 150,
+    lastInteractionDate: new Date().toISOString(),
+    isGuest: true,
+    userId: 'guest',
+  };
+
+  it('renders pet name and age correctly', () => {
+    const { getByText } = render(
+      <StatusCard pet={mockPet} petName="🐱 Fluffy" petAge="1 year" />
+    );
+    expect(getByText('🐱 Fluffy')).toBeTruthy();
+    expect(getByText('1 year')).toBeTruthy();
+  });
+
+  it('renders money with correct accessibility attributes', () => {
+    const { getByLabelText } = render(
+      <StatusCard pet={mockPet} petName="🐱 Fluffy" petAge="1 year" />
+    );
+
+    // This looks for the element with the accessibility label "150 coins"
+    const moneyDisplay = getByLabelText('150 coins');
+
+    expect(moneyDisplay).toBeTruthy();
+    expect(moneyDisplay.props.accessibilityRole).toBe('text');
+  });
+
+  it('handles zero money correctly', () => {
+    const poorPet = { ...mockPet, money: 0 };
+    const { getByLabelText } = render(
+      <StatusCard pet={poorPet} petName="🐱 Fluffy" petAge="1 year" />
+    );
+
+    const moneyDisplay = getByLabelText('0 coins');
+    expect(moneyDisplay).toBeTruthy();
+  });
+});


### PR DESCRIPTION
This PR improves the accessibility of the `StatusCard` component by grouping the currency display (icon + value) into a single accessible view.

### 💡 What
- Added `accessible={true}`, `accessibilityRole="text"`, and a localized `accessibilityLabel` to the money container in `StatusCard.tsx`.
- The label combines the numeric value and the localized term for "coins" (e.g., "150 coins").

### 🎯 Why
- Previously, screen readers would read the emoji (as "Money bag") and the number separately, or skip the container context.
- Grouping them provides a clearer, more natural experience for users relying on assistive technology.

### ♿ Accessibility
- **Grouping:** Treats icon and text as a single unit.
- **Labeling:** Uses `t('common.coins')` to ensure the label is localized (e.g., "moedas" in Portuguese).

### 🧪 Verification
- Added `src/components/__tests__/StatusCard.test.tsx` to verify the presence of the accessibility label.
- Ran `pnpm jest src/components/__tests__/StatusCard.test.tsx` (Passed).


---
*PR created automatically by Jules for task [8214992467946300186](https://jules.google.com/task/8214992467946300186) started by @az1nn*