### PR TITLE
🎨 Palette: Accessible Money Display in StatusCard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,7 @@
 ## 2026-05-24 - [Testing Reanimated Components]
 **Learning:** Testing components using `react-native-reanimated` with `react-test-renderer` requires strict environment mocking, specifically `findNodeHandle` in `react-native` mock, or mocking the library entirely to avoid DOM-related errors (like `getBoundingClientRect`).
 **Action:** When adding Reanimated to existing components, update `jest.setup.js` to include `findNodeHandle: jest.fn()` in the `react-native` mock, or wrap the component in a test that mocks `react-native-reanimated` logic.
+
+## 2026-05-25 - [Grouping Visual Elements for Accessibility]
+**Learning:** Visual groups like "Icon + Value" (e.g., 💰 100) are often read as separate, disjointed items by screen readers.
+**Action:** Wrap related visual elements in a container with `accessible={true}`, `accessibilityRole`, and a descriptive `accessibilityLabel` that provides context (e.g., "100 coins") to present them as a single semantic unit.

--- a/src/components/StatusCard.tsx
+++ b/src/components/StatusCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Pet } from '../types';
 import { EnhancedStatusBar } from './EnhancedStatusBar';
 import { useResponsive } from '../hooks/useResponsive';
@@ -17,6 +18,7 @@ export const StatusCard: React.FC<StatusCardProps> = ({
   petName,
   petAge,
 }) => {
+  const { t } = useTranslation();
   const { fs, spacing } = useResponsive();
 
   const dynamicStyles = {
@@ -55,7 +57,12 @@ export const StatusCard: React.FC<StatusCardProps> = ({
         <View style={styles.leftColumn}>
           <Text style={[styles.petName, dynamicStyles.petName]}>{petName}</Text>
           <Text style={[styles.petAge, dynamicStyles.petAge]}>{petAge}</Text>
-          <View style={[styles.moneyContainer, dynamicStyles.moneyContainer]}>
+          <View
+            style={[styles.moneyContainer, dynamicStyles.moneyContainer]}
+            accessible={true}
+            accessibilityRole="text"
+            accessibilityLabel={`${pet.money ?? 0} ${t('common.coins')}`}
+          >
             <Text style={[styles.coinIcon, dynamicStyles.coinIcon]}>💰</Text>
             <Text style={[styles.moneyValue, dynamicStyles.moneyValue]}>{pet.money ?? 0}</Text>
           </View>

--- a/src/components/__tests__/StatusCard.test.tsx
+++ b/src/components/__tests__/StatusCard.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { StatusCard } from '../StatusCard';
+import { Pet } from '../../types';
+
+// Mock useTranslation
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      if (key === 'common.coins') return 'coins';
+      return key;
+    },
+  }),
+}));
+
+// Mock useResponsive
+jest.mock('../../hooks/useResponsive', () => ({
+  useResponsive: () => ({
+    fs: (size: number) => size,
+    spacing: (size: number) => size,
+    deviceType: 'phone',
+  }),
+}));
+
+// Mock EnhancedStatusBar to avoid rendering child components
+jest.mock('../EnhancedStatusBar', () => ({
+  EnhancedStatusBar: () => null,
+}));
+
+describe('StatusCard', () => {
+  const mockPet: Pet = {
+    id: '123',
+    name: 'Fluffy',
+    type: 'cat',
+    color: 'base',
+    gender: 'female',
+    hunger: 50,
+    hygiene: 50,
+    energy: 50,
+    happiness: 50,
+    health: 50,
+    money: 100,
+    clothes: { head: null, eyes: null, torso: null, paws: null },
+    createdAt: Date.now(),
+    lastUpdated: Date.now(),
+  };
+
+  it('renders pet name and age', () => {
+    const { getByText } = render(
+      <StatusCard pet={mockPet} petName="🐱 Fluffy" petAge="1 year" />
+    );
+
+    expect(getByText('🐱 Fluffy')).toBeTruthy();
+    expect(getByText('1 year')).toBeTruthy();
+  });
+
+  it('displays money with accessible label', () => {
+    const { getByLabelText } = render(
+      <StatusCard pet={mockPet} petName="🐱 Fluffy" petAge="1 year" />
+    );
+
+    // This expects the container to have accessibilityLabel="100 coins"
+    const moneyContainer = getByLabelText('100 coins');
+    expect(moneyContainer).toBeTruthy();
+    expect(moneyContainer.props.accessibilityRole).toBe('text');
+  });
+});


### PR DESCRIPTION
This PR improves the accessibility of the money indicator in the `StatusCard` component. Previously, the icon ("💰") and the value (e.g., "100") were read as separate elements by screen readers. This change wraps them in a container with `accessibilityRole="text"` and a descriptive `accessibilityLabel` (e.g., "100 coins") so they are announced as a single, meaningful unit.

I also added a unit test `src/components/__tests__/StatusCard.test.tsx` to verify these accessibility properties are correctly applied.

---
*PR created automatically by Jules for task [6044552772051547256](https://jules.google.com/task/6044552772051547256) started by @az1nn*