### PR TITLE
🎨 Palette: StatusCard Money Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,7 @@
 ## 2026-05-24 - [Testing Reanimated Components]
 **Learning:** Testing components using `react-native-reanimated` with `react-test-renderer` requires strict environment mocking, specifically `findNodeHandle` in `react-native` mock, or mocking the library entirely to avoid DOM-related errors (like `getBoundingClientRect`).
 **Action:** When adding Reanimated to existing components, update `jest.setup.js` to include `findNodeHandle: jest.fn()` in the `react-native` mock, or wrap the component in a test that mocks `react-native-reanimated` logic.
+
+## 2026-05-24 - [Semantic Grouping of Values and Icons]
+**Learning:** Displays that combine an icon and a value (like "💰 100") are often read as two separate, disconnected items by screen readers.
+**Action:** Wrap the icon and value in a container View with `accessible={true}`, `accessibilityRole="text"`, and a constructed `accessibilityLabel` (e.g., "100 coins") to present them as a single semantic unit.

--- a/src/components/StatusCard.tsx
+++ b/src/components/StatusCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Pet } from '../types';
 import { EnhancedStatusBar } from './EnhancedStatusBar';
 import { useResponsive } from '../hooks/useResponsive';
@@ -17,6 +18,7 @@ export const StatusCard: React.FC<StatusCardProps> = ({
   petName,
   petAge,
 }) => {
+  const { t } = useTranslation();
   const { fs, spacing } = useResponsive();
 
   const dynamicStyles = {
@@ -55,7 +57,12 @@ export const StatusCard: React.FC<StatusCardProps> = ({
         <View style={styles.leftColumn}>
           <Text style={[styles.petName, dynamicStyles.petName]}>{petName}</Text>
           <Text style={[styles.petAge, dynamicStyles.petAge]}>{petAge}</Text>
-          <View style={[styles.moneyContainer, dynamicStyles.moneyContainer]}>
+          <View
+            style={[styles.moneyContainer, dynamicStyles.moneyContainer]}
+            accessible={true}
+            accessibilityRole="text"
+            accessibilityLabel={`${pet.money ?? 0} ${t('common.coins')}`}
+          >
             <Text style={[styles.coinIcon, dynamicStyles.coinIcon]}>💰</Text>
             <Text style={[styles.moneyValue, dynamicStyles.moneyValue]}>{pet.money ?? 0}</Text>
           </View>

--- a/src/components/__tests__/StatusCard.test.tsx
+++ b/src/components/__tests__/StatusCard.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { StatusCard } from '../StatusCard';
+import { Pet } from '../../types';
+
+// Mock dependencies
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key === 'common.coins' ? 'coins' : key }),
+  initReactI18next: { type: '3rdParty', init: jest.fn() },
+}));
+
+jest.mock('../../hooks/useResponsive', () => ({
+  useResponsive: () => ({
+    deviceType: 'phone',
+    fs: (v: number) => v,
+    spacing: (v: number) => v,
+  }),
+}));
+
+// Mock EnhancedStatusBar to avoid rendering children and simplify test
+jest.mock('../EnhancedStatusBar', () => ({
+  EnhancedStatusBar: () => null,
+}));
+
+describe('StatusCard', () => {
+  const mockPet: Pet = {
+    id: '1',
+    name: 'Fluffy',
+    type: 'cat',
+    color: 'base',
+    gender: 'male',
+    money: 100,
+    health: 100,
+    hunger: 100,
+    happiness: 100,
+    energy: 100,
+    hygiene: 100,
+    clothes: { head: null, eyes: null, torso: null, paws: null },
+    createdAt: Date.now(),
+    lastUpdated: Date.now(),
+  };
+
+  it('renders correctly with accessibility attributes for money', () => {
+    const { getByLabelText, getByText } = render(
+      <StatusCard
+        pet={mockPet}
+        petName="Fluffy"
+        petAge="1 year"
+      />
+    );
+
+    // Verify visual elements
+    expect(getByText('Fluffy')).toBeTruthy();
+    expect(getByText('1 year')).toBeTruthy();
+    expect(getByText('100')).toBeTruthy(); // The value
+
+    // Verify accessibility grouping
+    // The label should be "100 coins" based on our mock translation
+    const moneyContainer = getByLabelText('100 coins');
+    expect(moneyContainer).toBeTruthy();
+    expect(moneyContainer.props.accessibilityRole).toBe('text');
+  });
+
+  it('handles zero money correctly in accessibility label', () => {
+    const poorPet = { ...mockPet, money: 0 };
+    const { getByLabelText } = render(
+      <StatusCard
+        pet={poorPet}
+        petName="Fluffy"
+        petAge="1 year"
+      />
+    );
+
+    const moneyContainer = getByLabelText('0 coins');
+    expect(moneyContainer).toBeTruthy();
+  });
+});


### PR DESCRIPTION
🎨 Palette: Improved accessibility of the money display in StatusCard.

💡 **What:**
Wrapped the money icon (💰) and value in `StatusCard` with a container `View` that has `accessible={true}` and a constructed `accessibilityLabel`.

🎯 **Why:**
Previously, screen readers would read the icon (as "Bag of Money") and the number ("100") separately, or worse, just the number without context. This change ensures users hear "100 coins" (or localized equivalent) as a single semantic unit.

♿ **Accessibility:**
- Added `accessibilityRole="text"` to the money container.
- Constructed localized `accessibilityLabel` using `i18next`.
- Verified with new unit tests.

---
*PR created automatically by Jules for task [17503758705050585912](https://jules.google.com/task/17503758705050585912) started by @az1nn*