### PR TITLE
Make StatusCard money display accessible

### DIFF
--- a/src/components/StatusCard.tsx
+++ b/src/components/StatusCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { Pet } from '../types';
 import { EnhancedStatusBar } from './EnhancedStatusBar';
 import { useResponsive } from '../hooks/useResponsive';
@@ -17,6 +18,7 @@ export const StatusCard: React.FC<StatusCardProps> = ({
   petName,
   petAge,
 }) => {
+  const { t } = useTranslation();
   const { fs, spacing } = useResponsive();
 
   const dynamicStyles = {
@@ -55,7 +57,12 @@ export const StatusCard: React.FC<StatusCardProps> = ({
         <View style={styles.leftColumn}>
           <Text style={[styles.petName, dynamicStyles.petName]}>{petName}</Text>
           <Text style={[styles.petAge, dynamicStyles.petAge]}>{petAge}</Text>
-          <View style={[styles.moneyContainer, dynamicStyles.moneyContainer]}>
+          <View
+            style={[styles.moneyContainer, dynamicStyles.moneyContainer]}
+            accessible={true}
+            accessibilityRole="text"
+            accessibilityLabel={`${pet.money ?? 0} ${t('common.coins')}`}
+          >
             <Text style={[styles.coinIcon, dynamicStyles.coinIcon]}>💰</Text>
             <Text style={[styles.moneyValue, dynamicStyles.moneyValue]}>{pet.money ?? 0}</Text>
           </View>

--- a/src/components/__tests__/StatusCard.test.tsx
+++ b/src/components/__tests__/StatusCard.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { StatusCard } from '../StatusCard';
+import { Pet } from '../../types';
+
+// Mock translations
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key === 'common.coins' ? 'coins' : key,
+  }),
+}));
+
+// Mock EnhancedStatusBar to avoid rendering child components
+jest.mock('../EnhancedStatusBar', () => ({
+  EnhancedStatusBar: () => 'EnhancedStatusBar',
+}));
+
+describe('StatusCard', () => {
+  const mockPet: Pet = {
+    id: 'test-id',
+    name: 'Test Pet',
+    type: 'cat',
+    color: 'base',
+    gender: 'male',
+    hunger: 50,
+    hygiene: 50,
+    money: 100,
+    energy: 50,
+    happiness: 50,
+    health: 50,
+    clothes: { head: null, eyes: null, torso: null, paws: null },
+    createdAt: Date.now(),
+    lastUpdated: Date.now(),
+  };
+
+  it('renders correctly with pet info', () => {
+    const { getByText } = render(
+      <StatusCard
+        pet={mockPet}
+        petName="Test Pet"
+        petAge="1 year"
+      />
+    );
+
+    expect(getByText('Test Pet')).toBeTruthy();
+    expect(getByText('1 year')).toBeTruthy();
+    expect(getByText('100')).toBeTruthy();
+  });
+
+  it('renders money container AS accessible text', () => {
+    const { getByText, getByLabelText } = render(
+      <StatusCard
+        pet={mockPet}
+        petName="Test Pet"
+        petAge="1 year"
+      />
+    );
+
+    // Should find the text '100'
+    expect(getByText('100')).toBeTruthy();
+
+    // Should find accessible label "100 coins"
+    expect(getByLabelText('100 coins')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
🎨 **Palette: StatusCard Accessibility Improvement**

💡 **What:**
- Grouped the money icon (💰) and the numeric value into a single `View`.
- Added `accessible={true}` and `accessibilityRole="text"` to the container.
- Added a localized `accessibilityLabel` using the format `"{value} {t('common.coins')}"` (e.g., "100 coins").
- Added a new test file `src/components/__tests__/StatusCard.test.tsx` to verify the component renders and has the correct accessibility attributes.

🎯 **Why:**
- Previously, screen readers would likely read the emoji and the number separately, or fail to provide context for what the number represented.
- Grouping them provides a clear, cohesive piece of information ("100 coins") to users relying on assistive technology.
- The `StatusCard` component is used across almost all main screens (Home, Feed, Play, Bath, Vet, Wardrobe), so this small change improves the experience throughout the entire app.

📸 **Before/After:**
- **Visual:** No visual change (transparent container).
- **Audio (Screen Reader):**
    - *Before:* "Money bag, 100" (or similar, depending on SR)
    - *After:* "100 coins"

♿ **Accessibility:**
- Improved context for currency display.
- utilized `react-i18next` for the "coins" label to support multiple languages (EN/PT-BR).

---
*PR created automatically by Jules for task [17707886783033573870](https://jules.google.com/task/17707886783033573870) started by @az1nn*