### PR TITLE
🎨 Palette: Add dynamic color feedback to character count

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,7 @@
 ## 2026-05-24 - [Testing Reanimated Components]
 **Learning:** Testing components using `react-native-reanimated` with `react-test-renderer` requires strict environment mocking, specifically `findNodeHandle` in `react-native` mock, or mocking the library entirely to avoid DOM-related errors (like `getBoundingClientRect`).
 **Action:** When adding Reanimated to existing components, update `jest.setup.js` to include `findNodeHandle: jest.fn()` in the `react-native` mock, or wrap the component in a test that mocks `react-native-reanimated` logic.
+
+## 2026-05-24 - [Semantic Color Reuse]
+**Learning:** The design system's status colors (`COLORS.STAT_LEVELS`) are effective for more than just progress bars—they work well for input constraints (e.g., character limits) to create a consistent "warning/critical" visual language across the app.
+**Action:** Reuse existing semantic color tokens for validation feedback instead of introducing new ad-hoc colors, ensuring visual consistency.

--- a/src/screens/CreatePetScreen.tsx
+++ b/src/screens/CreatePetScreen.tsx
@@ -26,6 +26,7 @@ import { PetType, PetColor, Gender } from '../types';
 import { BackButtonIcon } from '../hooks/useBackButton';
 import { ScreenNavigationProp } from '../types/navigation';
 import { validatePetName, sanitizePetName } from '../utils/validation';
+import { COLORS } from '../config/constants';
 
 type Props = {
   navigation: ScreenNavigationProp<'CreatePet'>;
@@ -123,6 +124,17 @@ export const CreatePetScreen: React.FC<Props> = ({ navigation }) => {
     navigation.replace('Home');
   };
 
+  const getCharCountStyle = () => {
+    const length = name.length;
+    if (length >= 20) {
+      return { color: COLORS.STAT_LEVELS.LOW, fontWeight: 'bold' as const };
+    }
+    if (length >= 15) {
+      return { color: COLORS.STAT_LEVELS.MEDIUM, fontWeight: 'bold' as const };
+    }
+    return { color: '#666' };
+  };
+
   return (
     <SafeAreaView style={styles.container}>
       <TouchableOpacity
@@ -173,10 +185,9 @@ export const CreatePetScreen: React.FC<Props> = ({ navigation }) => {
             maxLength={20}
           />
           <Text
-            style={styles.charCount}
+            style={[styles.charCount, getCharCountStyle()]}
             accessibilityLabel={`${name.length} ${t('common.of', { defaultValue: 'of' })} 20`}
           >
-
             {name.length}/20
           </Text>
         </View>

--- a/src/screens/__tests__/CreatePetScreen.test.tsx
+++ b/src/screens/__tests__/CreatePetScreen.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { CreatePetScreen } from '../CreatePetScreen';
+import { COLORS } from '../../config/constants';
 
 // Mock dependencies
 jest.mock('../../context/PetContext', () => ({
@@ -82,5 +83,43 @@ describe('CreatePetScreen', () => {
     // Check if accessibility label is present (initially 0/20, then 6/20)
     // The current implementation uses t('common.of') which mocks to "common.of"
     expect(getByLabelText('6 common.of 20')).toBeTruthy();
+  });
+
+  it('updates character count color based on length', () => {
+    const { getByLabelText, getByPlaceholderText } = render(
+      <CreatePetScreen navigation={mockNavigation} />
+    );
+    const input = getByPlaceholderText('createPet.namePlaceholder');
+
+    // Default color (< 15 chars)
+    fireEvent.changeText(input, 'ShortName');
+    const charCountDefault = getByLabelText('9 common.of 20');
+    expect(charCountDefault.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining({ color: '#666' })])
+    );
+
+    // Warning color (>= 15 chars)
+    fireEvent.changeText(input, 'ThisNameIsLong!'); // 15 chars
+    const charCountWarning = getByLabelText('15 common.of 20');
+    expect(charCountWarning.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          color: COLORS.STAT_LEVELS.MEDIUM,
+          fontWeight: 'bold',
+        }),
+      ])
+    );
+
+    // Limit color (20 chars)
+    fireEvent.changeText(input, 'ThisNameIsVeryLong!!'); // 20 chars
+    const charCountLimit = getByLabelText('20 common.of 20');
+    expect(charCountLimit.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          color: COLORS.STAT_LEVELS.LOW,
+          fontWeight: 'bold',
+        }),
+      ])
+    );
   });
 });


### PR DESCRIPTION
🎨 **Palette Improvement: Dynamic Character Count Feedback**

**What:** Added dynamic visual feedback to the pet name input character counter in the Create Pet screen.

**Why:** Users previously received no visual warning when approaching the 20-character limit until they hit it (or tried to submit). This improves the micro-interaction by communicating constraints proactively.

**How:**
- The counter color now transitions from Grey -> Orange (Warning) -> Red (Limit).
- Uses the existing `COLORS.STAT_LEVELS` system to maintain visual consistency with the rest of the app (Status Bars, etc.).

**Verification:**
- ✅ Unit tests updated and passed.
- ✅ Visual styling logic verified via tests.

---
*PR created automatically by Jules for task [14682696856718509856](https://jules.google.com/task/14682696856718509856) started by @az1nn*