### PR TITLE
Refactor MenuScreen UI

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -35,12 +35,21 @@ jest.mock('react-native', () => {
     TouchableOpacity: mockComponent('TouchableOpacity'),
     ActivityIndicator: mockComponent('ActivityIndicator'),
     Image: mockComponent('Image'),
+    Modal: mockComponent('Modal'),
     ScrollView: mockComponent('ScrollView'),
     FlatList: mockComponent('FlatList'),
     TextInput: mockComponent('TextInput'),
     SafeAreaView: mockComponent('SafeAreaView'),
     KeyboardAvoidingView: mockComponent('KeyboardAvoidingView'),
     useWindowDimensions: jest.fn(() => ({ width: 375, height: 812, scale: 2, fontScale: 2 })),
+    Dimensions: {
+      get: jest.fn(() => ({ width: 375, height: 812 })),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    },
+    Alert: {
+      alert: jest.fn(),
+    },
     PixelRatio: {
       get: jest.fn(() => 2),
       getFontScale: jest.fn(() => 2),

--- a/src/screens/MenuScreen.tsx
+++ b/src/screens/MenuScreen.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import {
-    View,
-    Text,
-    TouchableOpacity,
-    StyleSheet,
-    SafeAreaView,
-    Image,
-    Alert,
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  SafeAreaView,
+  Image,
+  Alert,
+  ScrollView,
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { usePet } from '../context/PetContext';
@@ -14,18 +15,19 @@ import { useAuth } from '../context/AuthContext';
 import { ConfirmModal } from '../components/ConfirmModal';
 import { LanguageSelector } from '../components/LanguageSelector';
 import { ScreenNavigationProp } from '../types/navigation';
+import { Feather } from '@expo/vector-icons'; // Assuming Expo environment with vector icons
 
 type Props = {
   navigation: ScreenNavigationProp<'Menu'>;
 };
 
 export const MenuScreen: React.FC<Props> = ({ navigation }) => {
-    const { pet, removePet } = usePet();
-    const { user, isGuest, signOut } = useAuth();
-    const { t } = useTranslation();
-    const [showNewPetConfirm, setShowNewPetConfirm] = useState(false);
-    const [showDeletePetConfirm, setShowDeletePetConfirm] = useState(false);
-    const [showSignOutConfirm, setShowSignOutConfirm] = useState(false);
+  const { pet, removePet } = usePet();
+  const { user, isGuest, signOut } = useAuth();
+  const { t } = useTranslation();
+  const [showNewPetConfirm, setShowNewPetConfirm] = useState(false);
+  const [showDeletePetConfirm, setShowDeletePetConfirm] = useState(false);
+  const [showSignOutConfirm, setShowSignOutConfirm] = useState(false);
 
   const handleContinue = () => {
     if (pet) {
@@ -58,73 +60,88 @@ export const MenuScreen: React.FC<Props> = ({ navigation }) => {
     await removePet();
   };
 
-    const handleSignOut = () => {
-        setShowSignOutConfirm(true);
-    };
+  const handleSignOut = () => {
+    setShowSignOutConfirm(true);
+  };
 
-    const handleConfirmSignOut = async () => {
-        setShowSignOutConfirm(false);
-        try {
-            await signOut();
-        } catch (error) {
-            Alert.alert('Error', 'Failed to sign out. Please try again.');
-        }
-    };
+  const handleConfirmSignOut = async () => {
+    setShowSignOutConfirm(false);
+    try {
+      await signOut();
+    } catch (error) {
+      Alert.alert('Error', 'Failed to sign out. Please try again.');
+    }
+  };
 
-    return (
-        <SafeAreaView style={styles.container}>
-            {/* User Info Header */}
-            <View style={styles.header}>
-                <View style={styles.userInfoContainer}>
-                    {user?.photo && (
-                        <Image
-                            source={{ uri: user.photo }}
-                            style={styles.userPhoto}
-                        />
-                    )}
-                    <View style={styles.userTextContainer}>
-                        <Text style={styles.userName}>
-                            {user ? `Welcome, ${user.name}` : 'Guest User'}
-                        </Text>
-                        {user?.email && (
-                            <Text style={styles.userEmail}>{user.email}</Text>
-                        )}
-                    </View>
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Profile Card */}
+        <View style={styles.profileCard}>
+          <View style={styles.profileHeader}>
+            <View style={styles.avatarContainer}>
+              {user?.photo ? (
+                <Image source={{ uri: user.photo }} style={styles.avatar} />
+              ) : (
+                <View style={styles.defaultAvatar}>
+                  <Text style={styles.defaultAvatarText}>
+                    {user?.name ? user.name.charAt(0).toUpperCase() : 'G'}
+                  </Text>
                 </View>
-
-                {!isGuest && (
-                    <TouchableOpacity
-                        style={styles.signOutButton}
-                        onPress={handleSignOut}
-                    >
-                        <Text style={styles.signOutButtonText}>Sign Out</Text>
-                    </TouchableOpacity>
-                )}
+              )}
             </View>
-
-            {/* Guest Login Prompt */}
-            {isGuest && (
-                <View style={styles.guestBannerContainer}>
-                    <Text style={styles.guestBannerText}>
-                        Login to save your progress online
-                    </Text>
+            <View style={styles.userInfo}>
+              <Text style={styles.userName} numberOfLines={1}>
+                {user ? user.name : 'Guest User'}
+              </Text>
+              {user?.email && (
+                <Text style={styles.userEmail} numberOfLines={1}>
+                  {user.email}
+                </Text>
+              )}
+              {isGuest && (
+                <View style={styles.guestBadge}>
+                  <Text style={styles.guestBadgeText}>Guest Mode</Text>
                 </View>
+              )}
+            </View>
+            {!isGuest && (
+              <TouchableOpacity
+                style={styles.signOutButton}
+                onPress={handleSignOut}
+                accessibilityRole="button"
+                accessibilityLabel="Sign Out"
+              >
+                <Feather name="log-out" size={20} color="#9b59b6" />
+              </TouchableOpacity>
             )}
+          </View>
 
-            <View style={styles.content}>
-                <Text style={styles.title}>{t('menu.title')}</Text>
-                <Text style={styles.subtitle}>{t('menu.subtitle')}</Text>
-
-        {/* Language Selector */}
-        <View style={styles.languageContainer}>
-          <LanguageSelector />
+          {isGuest && (
+            <View style={styles.guestMessage}>
+              <Text style={styles.guestMessageText}>
+                Login to save your progress online
+              </Text>
+            </View>
+          )}
         </View>
 
-        <View style={styles.buttonContainer}>
-          {pet && (
+        {/* Title Section */}
+        <View style={styles.titleContainer}>
+          <Text style={styles.title}>{t('menu.title')}</Text>
+          <Text style={styles.subtitle}>{t('menu.subtitle')}</Text>
+        </View>
+
+        {/* Main Actions */}
+        <View style={styles.actionContainer}>
+          {pet ? (
             <TouchableOpacity
-              style={styles.continueButton}
+              style={styles.heroCard}
               onPress={handleContinue}
+              activeOpacity={0.9}
               accessibilityRole="button"
               accessibilityLabel={t('menu.continueWith', {
                 name: pet.name,
@@ -132,41 +149,62 @@ export const MenuScreen: React.FC<Props> = ({ navigation }) => {
               })}
               accessibilityHint={t('menu.continueHint')}
             >
-              <Text style={styles.continueButtonText}>
-                {t('menu.continueWith', {
-                  name: pet.name,
-                  emoji: pet.type === 'cat' ? '🐱' : '🐶',
-                })}
-              </Text>
+              <View style={styles.heroContent}>
+                <Text style={styles.heroEmoji}>
+                  {pet.type === 'cat' ? '🐱' : '🐶'}
+                </Text>
+                <View style={styles.heroTextContainer}>
+                  <Text style={styles.heroTitle}>{pet.name}</Text>
+                  <Text style={styles.heroSubtitle}>
+                    {t('menu.continueHint')}
+                  </Text>
+                </View>
+                <Feather name="chevron-right" size={32} color="#fff" style={styles.heroIcon} />
+              </View>
             </TouchableOpacity>
-          )}
-
-          {!pet && (
+          ) : (
             <TouchableOpacity
-              style={styles.newPetButton}
+              style={styles.heroCard}
               onPress={handleNewPet}
+              activeOpacity={0.9}
               accessibilityRole="button"
               accessibilityLabel={t('menu.createNewPet')}
               accessibilityHint={t('menu.createPetHint')}
             >
-              <Text style={styles.newPetButtonText}>{t('menu.createNewPet')}</Text>
+              <View style={styles.heroContent}>
+                <Text style={styles.heroEmoji}>✨</Text>
+                <View style={styles.heroTextContainer}>
+                  <Text style={styles.heroTitle}>{t('menu.createNewPet')}</Text>
+                  <Text style={styles.heroSubtitle}>Start a new adventure</Text>
+                </View>
+                <Feather name="plus-circle" size={32} color="#fff" style={styles.heroIcon} />
+              </View>
             </TouchableOpacity>
           )}
 
-          {pet && (
-            <TouchableOpacity
-              style={styles.deletePetButton}
-              onPress={handleDeletePet}
-              accessibilityRole="button"
-              accessibilityLabel={t('menu.deletePet')}
-              accessibilityHint={t('menu.deletePetHint')}
-            >
-              <Text style={styles.deletePetButtonText}>{t('menu.deletePet')}</Text>
-            </TouchableOpacity>
-          )}
+          {/* Secondary Actions Grid */}
+          <View style={styles.secondaryActions}>
+            <View style={styles.languageCard}>
+               <LanguageSelector />
+            </View>
+
+            {pet && (
+              <TouchableOpacity
+                style={styles.deleteCard}
+                onPress={handleDeletePet}
+                accessibilityRole="button"
+                accessibilityLabel={t('menu.deletePet')}
+                accessibilityHint={t('menu.deletePetHint')}
+              >
+                <Feather name="trash-2" size={20} color="#FF6B6B" />
+                <Text style={styles.deleteText}>{t('common.delete')}</Text>
+              </TouchableOpacity>
+            )}
+          </View>
         </View>
-      </View>
+      </ScrollView>
 
+      {/* Modals */}
       <ConfirmModal
         visible={showNewPetConfirm}
         title={t('menu.createPetModal.title')}
@@ -178,167 +216,213 @@ export const MenuScreen: React.FC<Props> = ({ navigation }) => {
         onCancel={() => setShowNewPetConfirm(false)}
       />
 
-            <ConfirmModal
-                visible={showDeletePetConfirm}
-                title={t('menu.deletePetModal.title')}
-                message={pet ? t('menu.deletePetModal.message', { name: pet.name }) : ''}
-                confirmText={t('menu.deletePetModal.confirmText')}
-                cancelText={t('menu.deletePetModal.cancelText')}
-                confirmStyle="destructive"
-                onConfirm={handleConfirmDeletePet}
-                onCancel={() => setShowDeletePetConfirm(false)}
-            />
+      <ConfirmModal
+        visible={showDeletePetConfirm}
+        title={t('menu.deletePetModal.title')}
+        message={pet ? t('menu.deletePetModal.message', { name: pet.name }) : ''}
+        confirmText={t('menu.deletePetModal.confirmText')}
+        cancelText={t('menu.deletePetModal.cancelText')}
+        confirmStyle="destructive"
+        onConfirm={handleConfirmDeletePet}
+        onCancel={() => setShowDeletePetConfirm(false)}
+      />
 
-            <ConfirmModal
-                visible={showSignOutConfirm}
-                title="Sign Out"
-                message="Are you sure you want to sign out? Your pet data will be preserved."
-                confirmText="Sign Out"
-                cancelText="Cancel"
-                confirmStyle="destructive"
-                onConfirm={handleConfirmSignOut}
-                onCancel={() => setShowSignOutConfirm(false)}
-            />
-        </SafeAreaView>
-    );
+      <ConfirmModal
+        visible={showSignOutConfirm}
+        title="Sign Out"
+        message="Are you sure you want to sign out? Your pet data will be preserved."
+        confirmText="Sign Out"
+        cancelText="Cancel"
+        confirmStyle="destructive"
+        onConfirm={handleConfirmSignOut}
+        onCancel={() => setShowSignOutConfirm(false)}
+      />
+    </SafeAreaView>
+  );
 };
 
 const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        backgroundColor: '#f5f0ff',
-    },
-    header: {
-        backgroundColor: '#ffffff',
-        paddingHorizontal: 16,
-        paddingVertical: 12,
-        borderBottomWidth: 1,
-        borderBottomColor: '#e0e0e0',
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-    },
-    userInfoContainer: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        flex: 1,
-    },
-    userPhoto: {
-        width: 40,
-        height: 40,
-        borderRadius: 20,
-        marginRight: 12,
-    },
-    userTextContainer: {
-        flex: 1,
-    },
-    userName: {
-        fontSize: 14,
-        fontWeight: '600',
-        color: '#333333',
-    },
-    userEmail: {
-        fontSize: 12,
-        color: '#999999',
-        marginTop: 2,
-    },
-    signOutButton: {
-        paddingHorizontal: 12,
-        paddingVertical: 6,
-        borderRadius: 4,
-        backgroundColor: '#f5f0ff',
-        borderWidth: 1,
-        borderColor: '#9b59b6',
-    },
-    signOutButtonText: {
-        color: '#9b59b6',
-        fontSize: 12,
-        fontWeight: '500',
-    },
-    guestBannerContainer: {
-        backgroundColor: '#fff3cd',
-        padding: 12,
-        borderBottomWidth: 1,
-        borderBottomColor: '#ffc107',
-    },
-    guestBannerText: {
-        color: '#856404',
-        fontSize: 13,
-        fontWeight: '500',
-        textAlign: 'center',
-    },
-    content: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-        padding: 24,
-    },
-    title: {
-        fontSize: 42,
-        fontWeight: 'bold',
-        color: '#9b59b6',
-        marginBottom: 8,
-    },
-    subtitle: {
-        fontSize: 18,
-        color: '#666',
-        marginBottom: 24,
-    },
-    languageContainer: {
-        marginBottom: 24,
-    },
-    buttonContainer: {
-        width: '100%',
-    },
-    continueButton: {
-        backgroundColor: '#9b59b6',
-        paddingVertical: 18,
-        paddingHorizontal: 32,
-        borderRadius: 16,
-        alignItems: 'center',
-        shadowColor: '#9b59b6',
-        shadowOffset: { width: 0, height: 4 },
-        shadowOpacity: 0.3,
-        shadowRadius: 8,
-        elevation: 5,
-        marginBottom: 16,
-    },
-    continueButtonText: {
-        color: '#fff',
-        fontSize: 18,
-        fontWeight: 'bold',
-    },
-    newPetButton: {
-        backgroundColor: '#9b59b6',
-        paddingVertical: 18,
-        paddingHorizontal: 32,
-        borderRadius: 16,
-        alignItems: 'center',
-        shadowColor: '#9b59b6',
-        shadowOffset: { width: 0, height: 4 },
-        shadowOpacity: 0.3,
-        shadowRadius: 8,
-        elevation: 5,
-        marginBottom: 16,
-    },
-    newPetButtonText: {
-        color: '#fff',
-        fontSize: 18,
-        fontWeight: 'bold',
-    },
-    deletePetButton: {
-        backgroundColor: '#fff',
-        paddingVertical: 18,
-        paddingHorizontal: 32,
-        borderRadius: 16,
-        alignItems: 'center',
-        borderWidth: 2,
-        borderColor: '#F44336',
-        shadowOpacity: 0.1,
-    },
-    deletePetButtonText: {
-        color: '#F44336',
-        fontSize: 18,
-        fontWeight: 'bold',
-    },
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f0ff',
+  },
+  scrollContent: {
+    padding: 20,
+    paddingBottom: 40,
+  },
+  // Profile Card
+  profileCard: {
+    backgroundColor: '#fff',
+    borderRadius: 24,
+    padding: 16,
+    marginBottom: 32,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.05,
+    shadowRadius: 12,
+    elevation: 3,
+  },
+  profileHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  avatarContainer: {
+    marginRight: 16,
+  },
+  avatar: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    borderWidth: 3,
+    borderColor: '#f0e6ff',
+  },
+  defaultAvatar: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: '#f0e6ff',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  defaultAvatarText: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#9b59b6',
+  },
+  userInfo: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  userName: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: '#333',
+    marginBottom: 4,
+  },
+  userEmail: {
+    fontSize: 12,
+    color: '#888',
+    marginBottom: 6,
+  },
+  guestBadge: {
+    backgroundColor: '#fff3cd',
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 12,
+    alignSelf: 'flex-start',
+  },
+  guestBadgeText: {
+    fontSize: 10,
+    fontWeight: '600',
+    color: '#856404',
+  },
+  signOutButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: '#f8f9fa',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  guestMessage: {
+    marginTop: 16,
+    paddingTop: 12,
+    borderTopWidth: 1,
+    borderTopColor: '#f0f0f0',
+  },
+  guestMessageText: {
+    fontSize: 12,
+    color: '#856404',
+    textAlign: 'center',
+  },
+  // Title
+  titleContainer: {
+    alignItems: 'center',
+    marginBottom: 32,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: '800',
+    color: '#9b59b6',
+    marginBottom: 8,
+    letterSpacing: 0.5,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#666',
+    fontWeight: '500',
+  },
+  // Actions
+  actionContainer: {
+    gap: 16,
+  },
+  heroCard: {
+    backgroundColor: '#9b59b6',
+    borderRadius: 24,
+    padding: 24,
+    shadowColor: '#9b59b6',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.3,
+    shadowRadius: 16,
+    elevation: 8,
+    width: '100%',
+  },
+  heroContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  heroEmoji: {
+    fontSize: 48,
+    marginRight: 20,
+  },
+  heroTextContainer: {
+    flex: 1,
+  },
+  heroTitle: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#fff',
+    marginBottom: 4,
+  },
+  heroSubtitle: {
+    fontSize: 14,
+    color: 'rgba(255, 255, 255, 0.9)',
+    fontWeight: '500',
+  },
+  heroIcon: {
+    opacity: 0.8,
+  },
+  secondaryActions: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginTop: 8,
+    gap: 12,
+  },
+  languageCard: {
+    flex: 1,
+    // Language selector usually has its own styling, but we wrap it to align
+    justifyContent: 'center',
+  },
+  deleteCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#ffebeb',
+    shadowColor: '#FF6B6B',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  deleteText: {
+    color: '#FF6B6B',
+    fontWeight: '600',
+    marginLeft: 8,
+    fontSize: 14,
+  },
 });

--- a/src/screens/__tests__/MenuScreen.test.tsx
+++ b/src/screens/__tests__/MenuScreen.test.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { MenuScreen } from '../MenuScreen';
+
+// Mock dependencies
+const mockRemovePet = jest.fn();
+const mockSignOut = jest.fn();
+const mockUsePet = jest.fn();
+
+jest.mock('../../context/PetContext', () => ({
+  usePet: () => mockUsePet(),
+}));
+
+jest.mock('../../context/AuthContext', () => ({
+  useAuth: () => ({
+    user: { name: 'Test User', email: 'test@example.com', photo: 'http://test.com/photo.jpg' },
+    isGuest: false,
+    signOut: mockSignOut,
+  }),
+}));
+
+jest.mock('../../context/LanguageContext', () => ({
+  useLanguage: () => ({
+    language: 'en',
+    setLanguage: jest.fn(),
+  }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, params: any) => {
+      if (key === 'menu.continueWith') return `Continue with ${params.name} ${params.emoji}`;
+      return key;
+    },
+  }),
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Feather: 'Feather',
+}));
+
+// Mock navigation
+const mockNavigation = {
+  navigate: jest.fn(),
+} as unknown as any;
+
+describe('MenuScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: Pet exists
+    mockUsePet.mockReturnValue({
+      pet: { name: 'Fluffy', type: 'cat' },
+      removePet: mockRemovePet,
+    });
+  });
+
+  it('renders correctly with a pet', () => {
+    const { getByText } = render(<MenuScreen navigation={mockNavigation} />);
+
+    // Header
+    expect(getByText('Test User')).toBeTruthy();
+    expect(getByText('test@example.com')).toBeTruthy();
+
+    // Main Content
+    expect(getByText('menu.title')).toBeTruthy();
+
+    // Continue Button (Hero Card)
+    expect(getByText('Fluffy')).toBeTruthy();
+    expect(getByText('menu.continueHint')).toBeTruthy();
+
+    // Secondary Actions
+    expect(getByText('common.delete')).toBeTruthy();
+  });
+
+  it('renders correctly without a pet', () => {
+    mockUsePet.mockReturnValue({
+      pet: null,
+      removePet: mockRemovePet,
+    });
+
+    const { getByText, queryByText } = render(<MenuScreen navigation={mockNavigation} />);
+
+    // Create New Pet Button (Hero Card)
+    expect(getByText('menu.createNewPet')).toBeTruthy();
+    expect(getByText('Start a new adventure')).toBeTruthy();
+
+    // Delete button should NOT be present
+    expect(queryByText('common.delete')).toBeNull();
+  });
+
+  it('navigates to Home when continue is pressed', () => {
+    const { getByText } = render(<MenuScreen navigation={mockNavigation} />);
+
+    const continueBtn = getByText('Fluffy');
+    fireEvent.press(continueBtn);
+
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('Home');
+  });
+
+  it('navigates to CreatePet when Create is pressed (no pet)', () => {
+    mockUsePet.mockReturnValue({
+        pet: null,
+        removePet: mockRemovePet,
+    });
+
+    const { getByText } = render(<MenuScreen navigation={mockNavigation} />);
+
+    const createBtn = getByText('menu.createNewPet');
+    fireEvent.press(createBtn);
+
+    expect(mockNavigation.navigate).toHaveBeenCalledWith('CreatePet');
+  });
+
+  it('shows delete confirmation modal', () => {
+    const { getByText } = render(<MenuScreen navigation={mockNavigation} />);
+
+    const deleteBtn = getByText('common.delete');
+    fireEvent.press(deleteBtn);
+
+    // Check if modal title appears
+    expect(getByText('menu.deletePetModal.title')).toBeTruthy();
+  });
+
+  it('shows sign out confirmation', () => {
+    const { getByLabelText, getByText } = render(<MenuScreen navigation={mockNavigation} />);
+
+    const signOutBtn = getByLabelText('Sign Out');
+    fireEvent.press(signOutBtn);
+
+    // Check for modal message
+    expect(getByText('Are you sure you want to sign out? Your pet data will be preserved.')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
This PR refactors the `MenuScreen` to use a modern, card-based UI as requested.

**Changes:**
1.  **UI Redesign:**
    *   Replaced the vertical list of buttons with a card-based layout.
    *   **Profile Card:** Displays user avatar, name, email, and sign-out button in a contained card at the top.
    *   **Hero Cards:** The primary action ("Continue with Pet" or "Create New Pet") is now a large, prominent card with an emoji and clear text, using the primary purple color.
    *   **Secondary Actions:** The Language Selector and "Delete Pet" button are placed in a secondary row to reduce clutter and establish visual hierarchy.
2.  **Code Improvements:**
    *   Cleaned up unused styles and imports.
    *   Added `@expo/vector-icons` usage (Feather) for cleaner iconography (Play, Plus, Trash, Log Out).
3.  **Testing:**
    *   Added `src/screens/__tests__/MenuScreen.test.tsx` to verify rendering (with and without pet), navigation, and modal interactions.
    *   Updated `jest.setup.js` to include mocks for `Dimensions` and `Modal` which were missing and causing test failures.

**Verification:**
*   Ran `tsc` to ensure type safety.
*   Ran `npm test src/screens/__tests__/MenuScreen.test.tsx` and all 6 tests passed.

---
*PR created automatically by Jules for task [15001960487189569936](https://jules.google.com/task/15001960487189569936) started by @az1nn*