### PR TITLE
Add ColorTap game and game creation scaffolding system

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -24,6 +24,9 @@ import { MemoryMatchNavigator } from './src/screens/MemoryMatchNavigator';
 import { PetRunnerProvider } from './src/context/PetRunnerContext';
 import { PetRunnerNavigator } from './src/screens/PetRunnerNavigator';
 
+import { ColorTapProvider } from './src/context/ColorTapContext';
+import { ColorTapNavigator } from './src/screens/ColorTapNavigator';
+
 // Register the pet-care game
 gameRegistry.register({
   id: 'pet-care',
@@ -69,6 +72,19 @@ gameRegistry.register({
   category: 'casual',
   navigator: PetRunnerNavigator,
   providers: [PetRunnerProvider],
+  isEnabled: true,
+});
+
+
+// Register the colorTap game
+gameRegistry.register({
+  id: 'color-tap',
+  nameKey: 'selectGame.colorTap.name',
+  descriptionKey: 'selectGame.colorTap.description',
+  emoji: '🎨',
+  category: 'casual',
+  navigator: ColorTapNavigator,
+  providers: [ColorTapProvider],
   isEnabled: true,
 });
 

--- a/__mocks__/react-native-webview.js
+++ b/__mocks__/react-native-webview.js
@@ -1,0 +1,7 @@
+const React = require('react');
+
+const WebView = React.forwardRef(function WebView(props, ref) {
+  return React.createElement('View', { ref, ...props }, props.children);
+});
+
+module.exports = { WebView, default: WebView };

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
     '^.+\\.[jt]sx?$': 'babel-jest',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!.*((jest-)?react-native|@react-native(-community)?|@react-native/.*|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|react-native-reanimated|react-native-gesture-handler|react-native-safe-area-context|react-native-screens|react-native-get-random-values|react-native-google-mobile-ads|uuid|@shopify/react-native-skia|@react-native/js-polyfills|expo-haptics|expo-constants))',
+    'node_modules/(?!.*((jest-)?react-native|@react-native(-community)?|@react-native/.*|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|react-native-reanimated|react-native-gesture-handler|react-native-safe-area-context|react-native-screens|react-native-get-random-values|react-native-google-mobile-ads|react-native-webview|uuid|@shopify/react-native-skia|@react-native/js-polyfills|expo-haptics|expo-constants))',
 
   ],
   testMatch: [

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx}\"",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
+    "create-game": "node scripts/create-game.js",
     "backend:dev": "pnpm --dir backend run dev",
     "backend:start": "pnpm --dir backend run start"
   },
@@ -47,6 +48,7 @@
     "react-native-screens": "~3.29.0",
     "react-native-svg": "14.1.0",
     "react-native-web": "~0.19.6",
+    "react-native-webview": "13.8.6",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       react-native-web:
         specifier: ~0.19.6
         version: 0.19.13(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-native-webview:
+        specifier: 13.8.6
+        version: 13.8.6(react-native@0.73.2(@babel/core@7.28.6)(@babel/preset-env@7.28.6(@babel/core@7.28.6))(react@18.2.0))(react@18.2.0)
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
@@ -1710,41 +1713,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3816,24 +3827,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.19.0:
     resolution: {integrity: sha512-vSCKO7SDnZaFN9zEloKSZM5/kC5gbzUjoJQ43BvUpyTFUX7ACs/mDfl2Eq6fdz2+uWhUh7vf92c4EaaP4udEtA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.19.0:
     resolution: {integrity: sha512-0AFQKvVzXf9byrXUq9z0anMGLdZJS+XSDqidyijI5njIwj6MdbvX2UZK/c4FfNmeRa2N/8ngTffoIuOUit5eIQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.19.0:
     resolution: {integrity: sha512-SJoM8CLPt6ECCgSuWe+g0qo8dqQYVcPiW2s19dxkmSI5+Uu1GIRzyKA0b7QqmEXolA+oSJhQqCmJpzjY4CuZAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-x64-msvc@1.19.0:
     resolution: {integrity: sha512-C+VuUTeSUOAaBZZOPT7Etn/agx/MatzJzGRkeV+zEABmPuntv1zihncsi+AyGmjkkzq3wVedEy7h0/4S84mUtg==}
@@ -4648,6 +4663,12 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
+
+  react-native-webview@13.8.6:
+    resolution: {integrity: sha512-jtZ9OgB2AN6rhDwto6dNL3PtOtl/SI4VN93pZEPbMLvRjqHfxiUrilGllL5fKAXq5Ry5FJyfUi82A4Ii8olZ7A==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
 
   react-native@0.73.2:
     resolution: {integrity: sha512-7zj9tcUYpJUBdOdXY6cM8RcXYWkyql4kMyGZflW99E5EuFPoC7Ti+ZQSl7LP9ZPzGD0vMfslwyDW0I4tPWUCFw==}
@@ -11712,6 +11733,13 @@ snapshots:
       styleq: 0.1.3
     transitivePeerDependencies:
       - encoding
+
+  react-native-webview@13.8.6(react-native@0.73.2(@babel/core@7.28.6)(@babel/preset-env@7.28.6(@babel/core@7.28.6))(react@18.2.0))(react@18.2.0):
+    dependencies:
+      escape-string-regexp: 2.0.0
+      invariant: 2.2.4
+      react: 18.2.0
+      react-native: 0.73.2(@babel/core@7.28.6)(@babel/preset-env@7.28.6(@babel/core@7.28.6))(react@18.2.0)
 
   react-native@0.73.2(@babel/core@7.28.6)(@babel/preset-env@7.28.6(@babel/core@7.28.6))(react@18.2.0):
     dependencies:

--- a/scripts/create-game.js
+++ b/scripts/create-game.js
@@ -1,0 +1,832 @@
+#!/usr/bin/env node
+
+/**
+ * Game Creation Script
+ *
+ * Interactive CLI tool that scaffolds a new game from a Claude AI Artifact (.tsx file).
+ *
+ * Usage:
+ *   node scripts/create-game.js
+ *   node scripts/create-game.js --artifact path/to/artifact.tsx
+ *
+ * What it does:
+ *   1. Prompts for game metadata (id, name, description, emoji, category)
+ *   2. Reads a Claude Artifact .tsx file
+ *   3. Generates: Navigator, Context, HomeScreen, GameScreen
+ *   4. Updates: App.tsx, navigation types, locale files
+ *   5. The game immediately appears in the game selection screen
+ */
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+const ROOT = path.resolve(__dirname, '..');
+const SRC = path.join(ROOT, 'src');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function ask(rl, question, defaultValue) {
+  const suffix = defaultValue ? ` (${defaultValue})` : '';
+  return new Promise((resolve) => {
+    rl.question(`${question}${suffix}: `, (answer) => {
+      resolve(answer.trim() || defaultValue || '');
+    });
+  });
+}
+
+function toPascalCase(str) {
+  return str
+    .replace(/[^a-zA-Z0-9]+/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join('');
+}
+
+function toCamelCase(str) {
+  const pascal = toPascalCase(str);
+  return pascal.charAt(0).toLowerCase() + pascal.slice(1);
+}
+
+function toKebabCase(str) {
+  return str
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .toLowerCase()
+    .replace(/^-|-$/g, '');
+}
+
+/**
+ * Strips TypeScript / ES module syntax from artifact source code.
+ * Mirror of src/utils/artifactHtml.ts stripModuleSyntax (JS version for Node).
+ */
+function stripModuleSyntax(source) {
+  let code = source;
+  code = code.replace(/^import\s+.*?(?:from\s+['"].*?['"])?;?\s*$/gm, '');
+  code = code.replace(/^export\s+default\s+/gm, '');
+  code = code.replace(/^export\s+(?=(?:const|let|var|function|class|interface|type)\s)/gm, '');
+  code = code.replace(/^(?:interface|type)\s+\w+(?:<[^>]*>)?\s*=?\s*\{[^}]*\};?\s*$/gm, '');
+  code = code.replace(/^type\s+\w+(?:<[^>]*>)?\s*=\s*[^;]+;\s*$/gm, '');
+  code = code.replace(/:\s*React\.FC(?:<[^>]*>)?/g, '');
+  return code.trim();
+}
+
+/**
+ * Detects the main component name from artifact source.
+ */
+function detectComponentName(source) {
+  const defaultFnMatch = source.match(/export\s+default\s+function\s+(\w+)/);
+  if (defaultFnMatch) return defaultFnMatch[1];
+
+  const defaultIdMatch = source.match(/export\s+default\s+(\w+)\s*;/);
+  if (defaultIdMatch) return defaultIdMatch[1];
+
+  const constMatches = [
+    ...source.matchAll(
+      /(?:export\s+)?const\s+(\w+)\s*(?::\s*\w+(?:<[^>]*>)?\s*)?=\s*(?:\([^)]*\)\s*=>|\(\s*\)\s*=>|function)/g,
+    ),
+  ];
+  if (constMatches.length > 0) {
+    return constMatches[constMatches.length - 1][1];
+  }
+
+  const fnMatches = [...source.matchAll(/^function\s+(\w+)/gm)];
+  if (fnMatches.length > 0) {
+    return fnMatches[fnMatches.length - 1][1];
+  }
+
+  return 'App';
+}
+
+// ---------------------------------------------------------------------------
+// Template generators
+// ---------------------------------------------------------------------------
+
+function generateNavigator(pascal, gameId) {
+  return `import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../types/navigation';
+import { ${pascal}HomeScreen } from './${pascal}HomeScreen';
+import { ${pascal}GameScreen } from './${pascal}GameScreen';
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export const ${pascal}Navigator: React.FC = () => (
+  <Stack.Navigator
+    initialRouteName="${pascal}Home"
+    screenOptions={{ headerShown: false, animation: 'slide_from_right' }}
+  >
+    <Stack.Screen name="${pascal}Home" component={${pascal}HomeScreen} />
+    <Stack.Screen name="${pascal}Game" component={${pascal}GameScreen} />
+  </Stack.Navigator>
+);
+`;
+}
+
+function generateContext(pascal, camel, gameId) {
+  return `import React, { createContext, useContext, useState, useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useAuth } from './AuthContext';
+
+const STORAGE_KEY = '@game_${gameId}_best_score';
+
+interface ${pascal}ContextType {
+  bestScore: number;
+  updateBestScore: (score: number) => void;
+}
+
+const ${pascal}Context = createContext<${pascal}ContextType | null>(null);
+
+export const ${pascal}Provider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { user, isGuest } = useAuth();
+  const userId = user?.id || (isGuest ? 'guest' : 'guest');
+  const [bestScore, setBestScore] = useState(0);
+
+  useEffect(() => {
+    const loadScore = async () => {
+      try {
+        const stored = await AsyncStorage.getItem(\`\${STORAGE_KEY}:\${userId}\`);
+        if (stored !== null) {
+          setBestScore(Number(stored));
+        }
+      } catch {
+        // Ignore storage errors
+      }
+    };
+    loadScore();
+  }, [userId]);
+
+  const updateBestScore = (score: number) => {
+    if (score > bestScore) {
+      setBestScore(score);
+      AsyncStorage.setItem(\`\${STORAGE_KEY}:\${userId}\`, String(score)).catch(() => {});
+    }
+  };
+
+  return (
+    <${pascal}Context.Provider value={{ bestScore, updateBestScore }}>
+      {children}
+    </${pascal}Context.Provider>
+  );
+};
+
+export const use${pascal} = () => {
+  const ctx = useContext(${pascal}Context);
+  if (!ctx) {
+    throw new Error('use${pascal} must be used within ${pascal}Provider');
+  }
+  return ctx;
+};
+`;
+}
+
+function generateHomeScreen(pascal, camel, gameId) {
+  return `import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { ScreenNavigationProp } from '../types/navigation';
+import { use${pascal} } from '../context/${pascal}Context';
+
+type Props = {
+  navigation: ScreenNavigationProp<'${pascal}Home'>;
+};
+
+export const ${pascal}HomeScreen: React.FC<Props> = ({ navigation }) => {
+  const { t } = useTranslation();
+  const { bestScore } = use${pascal}();
+
+  const handlePlay = () => {
+    navigation.navigate('${pascal}Game');
+  };
+
+  const handleBack = () => {
+    navigation.getParent()?.goBack();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <TouchableOpacity style={styles.backButton} onPress={handleBack} accessibilityRole="button">
+        <Text style={styles.backText}>{t('common.back')}</Text>
+      </TouchableOpacity>
+
+      <View style={styles.content}>
+        <Text style={styles.title}>{t('${camel}.title')}</Text>
+        <Text style={styles.subtitle}>{t('${camel}.subtitle')}</Text>
+        <Text style={styles.instructions}>{t('${camel}.instructions')}</Text>
+
+        {bestScore > 0 && (
+          <View style={styles.scoreCard}>
+            <Text style={styles.scoreLabel}>{t('${camel}.bestScore')}</Text>
+            <Text style={styles.scoreValue}>{bestScore}</Text>
+          </View>
+        )}
+
+        <TouchableOpacity style={styles.playButton} onPress={handlePlay} accessibilityRole="button">
+          <Text style={styles.playText}>{t('${camel}.play')}</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f0ff',
+  },
+  backButton: {
+    padding: 16,
+    alignSelf: 'flex-start',
+  },
+  backText: {
+    fontSize: 16,
+    color: '#9b59b6',
+    fontWeight: '600',
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 32,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: '800',
+    color: '#9b59b6',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#666',
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  instructions: {
+    fontSize: 14,
+    color: '#888',
+    textAlign: 'center',
+    marginBottom: 32,
+    lineHeight: 20,
+  },
+  scoreCard: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 32,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    elevation: 3,
+    minWidth: 140,
+  },
+  scoreLabel: {
+    fontSize: 14,
+    color: '#888',
+    marginBottom: 4,
+  },
+  scoreValue: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: '#9b59b6',
+  },
+  playButton: {
+    backgroundColor: '#9b59b6',
+    borderRadius: 20,
+    paddingVertical: 16,
+    paddingHorizontal: 48,
+  },
+  playText: {
+    color: '#fff',
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+});
+`;
+}
+
+function generateGameScreen(pascal, camel, gameId, artifactSource) {
+  const componentName = detectComponentName(artifactSource);
+  const strippedCode = stripModuleSyntax(artifactSource);
+
+  // Escape backticks and ${} in the artifact source for template literal embedding
+  const escapedCode = strippedCode.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+
+  return `import React, { useState, useCallback } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../types/navigation';
+import { ArtifactGameAdapter, ArtifactMessage } from '../components/ArtifactGameAdapter';
+import { use${pascal} } from '../context/${pascal}Context';
+
+type Props = NativeStackScreenProps<RootStackParamList, '${pascal}Game'>;
+
+/**
+ * HTML content generated from the Claude AI Artifact.
+ * Original component name: ${componentName}
+ *
+ * The artifact communicates with React Native via window.RNBridge:
+ *   window.RNBridge.sendScore(score)   - report score updates
+ *   window.RNBridge.gameOver(score)    - signal game over
+ *   window.RNBridge.navigate('back')   - request navigation back
+ */
+const ARTIFACT_HTML = \`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>${pascal}</title>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"><\\/script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"><\\/script>
+  <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"><\\/script>
+  <script src="https://cdn.tailwindcss.com"><\\/script>
+  <script>
+    window.RNBridge = {
+      send: function(message) {
+        if (window.ReactNativeWebView) {
+          window.ReactNativeWebView.postMessage(JSON.stringify(message));
+        } else if (window.parent !== window) {
+          window.parent.postMessage(JSON.stringify(message), '*');
+        }
+      },
+      sendScore: function(score) { this.send({ type: 'scoreUpdate', payload: { score: score } }); },
+      gameOver: function(finalScore) { this.send({ type: 'gameOver', payload: { finalScore: finalScore } }); },
+      navigate: function(target) { this.send({ type: 'navigate', payload: { target: target || 'back' } }); }
+    };
+  <\\/script>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body, #root { width: 100%; height: 100%; overflow: hidden; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    const { useState, useEffect, useCallback, useRef, useMemo, useReducer, useContext, createContext } = React;
+
+    ${escapedCode}
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(React.createElement(${componentName}));
+  <\\/script>
+</body>
+</html>\`;
+
+export const ${pascal}GameScreen: React.FC<Props> = ({ navigation }) => {
+  const { t } = useTranslation();
+  const { updateBestScore } = use${pascal}();
+  const [score, setScore] = useState(0);
+  const [gameOver, setGameOver] = useState(false);
+
+  const handleScoreUpdate = useCallback(
+    (newScore: number) => {
+      setScore(newScore);
+    },
+    [],
+  );
+
+  const handleGameOver = useCallback(
+    (finalScore: number) => {
+      setScore(finalScore);
+      setGameOver(true);
+      updateBestScore(finalScore);
+    },
+    [updateBestScore],
+  );
+
+  const handleNavigate = useCallback(
+    (target: string) => {
+      if (target === 'back') {
+        navigation.goBack();
+      }
+    },
+    [navigation],
+  );
+
+  const handleBack = () => {
+    navigation.goBack();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={handleBack} accessibilityRole="button">
+          <Text style={styles.backText}>{t('common.back')}</Text>
+        </TouchableOpacity>
+        {score > 0 && <Text style={styles.scoreText}>{score}</Text>}
+      </View>
+
+      <View style={styles.gameArea}>
+        <ArtifactGameAdapter
+          htmlContent={ARTIFACT_HTML}
+          onScoreUpdate={handleScoreUpdate}
+          onGameOver={handleGameOver}
+          onNavigate={handleNavigate}
+        />
+      </View>
+
+      {gameOver && (
+        <View style={styles.overlay}>
+          <View style={styles.overlayCard}>
+            <Text style={styles.overlayTitle}>{t('${camel}.gameOver.title')}</Text>
+            <Text style={styles.overlayScore}>{score}</Text>
+            <TouchableOpacity
+              style={styles.playAgainButton}
+              onPress={() => {
+                setGameOver(false);
+                setScore(0);
+                // Force re-mount the WebView by navigating away and back
+                navigation.replace('${pascal}Game');
+              }}
+              accessibilityRole="button"
+            >
+              <Text style={styles.playAgainText}>{t('${camel}.gameOver.playAgain')}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f0ff',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  backText: {
+    fontSize: 16,
+    color: '#9b59b6',
+    fontWeight: '600',
+  },
+  scoreText: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: '#333',
+  },
+  gameArea: {
+    flex: 1,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  overlayCard: {
+    backgroundColor: '#fff',
+    borderRadius: 24,
+    padding: 32,
+    alignItems: 'center',
+    minWidth: 260,
+  },
+  overlayTitle: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#333',
+    marginBottom: 12,
+  },
+  overlayScore: {
+    fontSize: 40,
+    fontWeight: '800',
+    color: '#9b59b6',
+    marginBottom: 24,
+  },
+  playAgainButton: {
+    backgroundColor: '#9b59b6',
+    borderRadius: 16,
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+  },
+  playAgainText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+});
+`;
+}
+
+// ---------------------------------------------------------------------------
+// File modifiers
+// ---------------------------------------------------------------------------
+
+function updateNavigationTypes(pascal) {
+  const filePath = path.join(SRC, 'types', 'navigation.ts');
+  let content = fs.readFileSync(filePath, 'utf-8');
+
+  // Check if routes already exist
+  if (content.includes(`${pascal}Home`)) {
+    console.log(`  [skip] Navigation types already contain ${pascal}Home`);
+    return;
+  }
+
+  // Find the closing }; of RootStackParamList (first }; after the type declaration)
+  const typeStart = content.indexOf('export type RootStackParamList');
+  if (typeStart === -1) {
+    console.error('  [error] Could not find RootStackParamList in navigation.ts');
+    return;
+  }
+  const lastIndex = content.indexOf('};', typeStart);
+  if (lastIndex === -1) {
+    console.error('  [error] Could not find closing }; for RootStackParamList');
+    return;
+  }
+
+  const insertion = `  /** ${pascal} home screen */\n  ${pascal}Home: undefined;\n  /** ${pascal} game screen */\n  ${pascal}Game: undefined;\n`;
+
+  content = content.slice(0, lastIndex) + insertion + content.slice(lastIndex);
+  fs.writeFileSync(filePath, content, 'utf-8');
+  console.log(`  [updated] ${filePath}`);
+}
+
+function updateAppTsx(pascal, camel, gameId, emoji, category) {
+  const filePath = path.join(ROOT, 'App.tsx');
+  let content = fs.readFileSync(filePath, 'utf-8');
+
+  // Check if already registered
+  if (content.includes(`id: '${gameId}'`)) {
+    console.log(`  [skip] App.tsx already contains registration for ${gameId}`);
+    return;
+  }
+
+  // Add imports after the last import block
+  const importLines = [
+    `import { ${pascal}Provider } from './src/context/${pascal}Context';`,
+    `import { ${pascal}Navigator } from './src/screens/${pascal}Navigator';`,
+  ];
+
+  // Find last import statement
+  const importRegex = /^import\s+.*;\s*$/gm;
+  let lastImportIndex = 0;
+  let match;
+  while ((match = importRegex.exec(content)) !== null) {
+    lastImportIndex = match.index + match[0].length;
+  }
+
+  // Insert new imports right after the last existing import
+  const newImports = '\n' + importLines.join('\n');
+  content =
+    content.slice(0, lastImportIndex) +
+    newImports +
+    content.slice(lastImportIndex);
+
+  // Add registration before "const Stack ="
+  const stackMarker = 'const Stack = createNativeStackNavigator';
+  const stackIndex = content.indexOf(stackMarker);
+  if (stackIndex === -1) {
+    console.error('  [error] Could not find Stack declaration in App.tsx');
+    return;
+  }
+
+  const registration = `
+// Register the ${camel} game
+gameRegistry.register({
+  id: '${gameId}',
+  nameKey: 'selectGame.${camel}.name',
+  descriptionKey: 'selectGame.${camel}.description',
+  emoji: '${emoji}',
+  category: '${category}',
+  navigator: ${pascal}Navigator,
+  providers: [${pascal}Provider],
+  isEnabled: true,
+});
+
+`;
+
+  content = content.slice(0, stackIndex) + registration + content.slice(stackIndex);
+  fs.writeFileSync(filePath, content, 'utf-8');
+  console.log(`  [updated] ${filePath}`);
+}
+
+function updateLocaleFile(filePath, camel, name, description) {
+  let content = fs.readFileSync(filePath, 'utf-8');
+  const json = JSON.parse(content);
+
+  // Add selectGame entry
+  if (!json.selectGame) json.selectGame = {};
+  if (!json.selectGame[camel]) {
+    json.selectGame[camel] = { name, description };
+  }
+
+  // Add game-specific i18n keys
+  if (!json[camel]) {
+    json[camel] = {
+      title: name,
+      subtitle: description,
+      instructions: `Play ${name} and try to beat your best score!`,
+      play: 'Play!',
+      bestScore: 'Best Score',
+      score: 'Score',
+      gameOver: {
+        title: 'Game Over!',
+        score: 'Score',
+        newBest: 'New Best!',
+        playAgain: 'Play Again',
+      },
+    };
+  }
+
+  fs.writeFileSync(filePath, JSON.stringify(json, null, 2) + '\n', 'utf-8');
+  console.log(`  [updated] ${filePath}`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses a CLI flag value: --flag value
+ */
+function getFlag(name) {
+  const idx = process.argv.indexOf(`--${name}`);
+  if (idx !== -1 && process.argv[idx + 1]) {
+    return process.argv[idx + 1];
+  }
+  return '';
+}
+
+async function main() {
+  console.log('');
+  console.log('====================================');
+  console.log('  Game Creation System');
+  console.log('  From Claude AI Artifact to Game');
+  console.log('====================================');
+  console.log('');
+
+  // Check for non-interactive mode (all required flags provided)
+  const flagArtifact = getFlag('artifact');
+  const flagName = getFlag('name');
+  const flagId = getFlag('id');
+  const flagDescription = getFlag('description');
+  const flagEmoji = getFlag('emoji');
+  const flagCategory = getFlag('category');
+  const isNonInteractive = flagArtifact && (flagName || flagId);
+
+  let rl = null;
+  if (!isNonInteractive) {
+    rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+  }
+
+  try {
+    // --- Collect user inputs ---
+
+    let artifactPath = flagArtifact;
+    if (!artifactPath && rl) {
+      artifactPath = await ask(rl, 'Path to Claude Artifact .tsx file');
+    }
+
+    if (!artifactPath) {
+      console.error('Error: --artifact <path> is required.');
+      console.error('Usage: node scripts/create-game.js --artifact path/to/artifact.tsx [--name "Game Name"] [--id game-id] [--description "..."] [--emoji "🎮"] [--category casual]');
+      process.exit(1);
+    }
+
+    // Resolve and validate artifact path
+    artifactPath = path.resolve(artifactPath);
+    if (!fs.existsSync(artifactPath)) {
+      console.error(`\nError: File not found: ${artifactPath}`);
+      console.error('Please provide a valid path to a .tsx artifact file.');
+      process.exit(1);
+    }
+
+    const artifactSource = fs.readFileSync(artifactPath, 'utf-8');
+    const detectedName = detectComponentName(artifactSource);
+
+    console.log(`Detected component: ${detectedName}`);
+    console.log('');
+
+    const defaultDisplayName = detectedName.replace(/([A-Z])/g, ' $1').trim();
+    const gameName = flagName || (rl ? await ask(rl, 'Game name (display name)', defaultDisplayName) : defaultDisplayName);
+    const gameId = flagId || (rl ? await ask(rl, 'Game ID (kebab-case)', toKebabCase(gameName)) : toKebabCase(gameName));
+    const description = flagDescription || (rl ? await ask(rl, 'Short description', `Play ${gameName}!`) : `Play ${gameName}!`);
+    const emoji = flagEmoji || (rl ? await ask(rl, 'Emoji icon', '🎮') : '🎮');
+    const categoryInput = flagCategory || (rl ? await ask(rl, 'Category (pet/puzzle/adventure/casual)', 'casual') : 'casual');
+    const category = ['pet', 'puzzle', 'adventure', 'casual'].includes(categoryInput)
+      ? categoryInput
+      : 'casual';
+
+    const pascal = toPascalCase(gameName);
+    const camel = toCamelCase(gameName);
+
+    console.log('--- Summary ---');
+    console.log(`  Game ID:      ${gameId}`);
+    console.log(`  Display Name: ${gameName}`);
+    console.log(`  Description:  ${description}`);
+    console.log(`  Emoji:        ${emoji}`);
+    console.log(`  Category:     ${category}`);
+    console.log(`  PascalCase:   ${pascal}`);
+    console.log(`  camelCase:    ${camel}`);
+    console.log(`  Component:    ${detectedName}`);
+    console.log('');
+
+    if (rl && !isNonInteractive) {
+      const confirm = await ask(rl, 'Proceed? (y/n)', 'y');
+      if (confirm.toLowerCase() !== 'y') {
+        console.log('Cancelled.');
+        process.exit(0);
+      }
+    }
+
+    // --- Generate files ---
+
+    console.log('\nGenerating files...\n');
+
+    // 1. Navigator
+    const navigatorPath = path.join(SRC, 'screens', `${pascal}Navigator.tsx`);
+    fs.writeFileSync(navigatorPath, generateNavigator(pascal, gameId), 'utf-8');
+    console.log(`  [created] ${navigatorPath}`);
+
+    // 2. Context
+    const contextPath = path.join(SRC, 'context', `${pascal}Context.tsx`);
+    fs.writeFileSync(contextPath, generateContext(pascal, camel, gameId), 'utf-8');
+    console.log(`  [created] ${contextPath}`);
+
+    // 3. Home Screen
+    const homeScreenPath = path.join(SRC, 'screens', `${pascal}HomeScreen.tsx`);
+    fs.writeFileSync(homeScreenPath, generateHomeScreen(pascal, camel, gameId), 'utf-8');
+    console.log(`  [created] ${homeScreenPath}`);
+
+    // 4. Game Screen (with embedded artifact)
+    const gameScreenPath = path.join(SRC, 'screens', `${pascal}GameScreen.tsx`);
+    fs.writeFileSync(gameScreenPath, generateGameScreen(pascal, camel, gameId, artifactSource), 'utf-8');
+    console.log(`  [created] ${gameScreenPath}`);
+
+    // 5. Copy the original artifact for reference
+    const artifactsDir = path.join(SRC, 'artifacts');
+    if (!fs.existsSync(artifactsDir)) {
+      fs.mkdirSync(artifactsDir, { recursive: true });
+    }
+    const artifactCopyPath = path.join(artifactsDir, `${gameId}.tsx`);
+    fs.copyFileSync(artifactPath, artifactCopyPath);
+    console.log(`  [copied]  ${artifactCopyPath}`);
+
+    // --- Update existing files ---
+
+    console.log('\nUpdating existing files...\n');
+
+    // 6. Navigation types
+    updateNavigationTypes(pascal);
+
+    // 7. App.tsx (imports + registration)
+    updateAppTsx(pascal, camel, gameId, emoji, category);
+
+    // 8. Locale files
+    const enPath = path.join(SRC, 'locales', 'en.json');
+    const ptPath = path.join(SRC, 'locales', 'pt-BR.json');
+    updateLocaleFile(enPath, camel, gameName, description);
+    updateLocaleFile(ptPath, camel, gameName, description);
+
+    // --- Done ---
+
+    console.log('\n====================================');
+    console.log('  Game created successfully!');
+    console.log('====================================');
+    console.log('');
+    console.log('Generated files:');
+    console.log(`  - src/screens/${pascal}Navigator.tsx`);
+    console.log(`  - src/context/${pascal}Context.tsx`);
+    console.log(`  - src/screens/${pascal}HomeScreen.tsx`);
+    console.log(`  - src/screens/${pascal}GameScreen.tsx`);
+    console.log(`  - src/artifacts/${gameId}.tsx`);
+    console.log('');
+    console.log('Updated files:');
+    console.log('  - App.tsx');
+    console.log('  - src/types/navigation.ts');
+    console.log('  - src/locales/en.json');
+    console.log('  - src/locales/pt-BR.json');
+    console.log('');
+    console.log('Next steps:');
+    console.log('  1. Run: pnpm start');
+    console.log('  2. Your game will appear in the game selection screen');
+    console.log('  3. To enable score reporting from your artifact, use:');
+    console.log('       window.RNBridge.sendScore(score)');
+    console.log('       window.RNBridge.gameOver(finalScore)');
+    console.log('       window.RNBridge.navigate("back")');
+    console.log('');
+  } finally {
+    if (rl) rl.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/src/artifacts/color-tap.tsx
+++ b/src/artifacts/color-tap.tsx
@@ -1,0 +1,180 @@
+import React, { useState, useEffect, useCallback } from 'react';
+
+/**
+ * Color Tap - Example Claude AI Artifact
+ *
+ * A simple color-matching tap game. Tap the circle that matches the
+ * color name displayed at the top. Score points for correct taps,
+ * and the game speeds up as you progress.
+ *
+ * This artifact demonstrates the RNBridge integration:
+ *   window.RNBridge.sendScore(score)
+ *   window.RNBridge.gameOver(finalScore)
+ */
+
+interface ColorOption {
+  name: string;
+  hex: string;
+}
+
+const COLORS: ColorOption[] = [
+  { name: 'Red', hex: '#ef4444' },
+  { name: 'Blue', hex: '#3b82f6' },
+  { name: 'Green', hex: '#22c55e' },
+  { name: 'Yellow', hex: '#eab308' },
+  { name: 'Purple', hex: '#a855f7' },
+  { name: 'Orange', hex: '#f97316' },
+];
+
+function shuffleArray<T>(array: T[]): T[] {
+  const shuffled = [...array];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+}
+
+const ColorTapGame: React.FC = () => {
+  const [score, setScore] = useState(0);
+  const [lives, setLives] = useState(3);
+  const [targetColor, setTargetColor] = useState<ColorOption>(COLORS[0]);
+  const [options, setOptions] = useState<ColorOption[]>([]);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [gameStarted, setGameStarted] = useState(false);
+  const [gameOver, setGameOver] = useState(false);
+  const [timeLeft, setTimeLeft] = useState(100);
+
+  const pickNewRound = useCallback(() => {
+    const target = COLORS[Math.floor(Math.random() * COLORS.length)];
+    const others = COLORS.filter((c) => c.name !== target.name);
+    const picked = shuffleArray(others).slice(0, 3);
+    const allOptions = shuffleArray([target, ...picked]);
+    setTargetColor(target);
+    setOptions(allOptions);
+    setTimeLeft(100);
+  }, []);
+
+  const startGame = () => {
+    setScore(0);
+    setLives(3);
+    setGameOver(false);
+    setGameStarted(true);
+    setFeedback(null);
+    pickNewRound();
+  };
+
+  useEffect(() => {
+    if (!gameStarted || gameOver) return;
+
+    const timer = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 0) {
+          setLives((l) => {
+            const newLives = l - 1;
+            if (newLives <= 0) {
+              setGameOver(true);
+              if (window.RNBridge) window.RNBridge.gameOver(score);
+            }
+            return newLives;
+          });
+          pickNewRound();
+          return 100;
+        }
+        return prev - 2;
+      });
+    }, 100);
+
+    return () => clearInterval(timer);
+  }, [gameStarted, gameOver, pickNewRound, score]);
+
+  const handleTap = (color: ColorOption) => {
+    if (gameOver) return;
+
+    if (color.name === targetColor.name) {
+      const newScore = score + 10;
+      setScore(newScore);
+      setFeedback('Correct!');
+      if (window.RNBridge) window.RNBridge.sendScore(newScore);
+    } else {
+      setFeedback('Wrong!');
+      const newLives = lives - 1;
+      setLives(newLives);
+      if (newLives <= 0) {
+        setGameOver(true);
+        if (window.RNBridge) window.RNBridge.gameOver(score);
+        return;
+      }
+    }
+
+    setTimeout(() => setFeedback(null), 400);
+    pickNewRound();
+  };
+
+  if (!gameStarted || gameOver) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-b from-indigo-900 to-purple-900 text-white">
+        <h1 className="text-4xl font-bold mb-4">Color Tap</h1>
+        {gameOver && (
+          <div className="text-center mb-6">
+            <p className="text-xl mb-2">Game Over!</p>
+            <p className="text-3xl font-bold text-yellow-300">Score: {score}</p>
+          </div>
+        )}
+        {!gameOver && (
+          <p className="text-lg text-gray-300 mb-6 text-center px-8">
+            Tap the circle that matches the color name!
+          </p>
+        )}
+        <button
+          onClick={startGame}
+          className="px-8 py-4 bg-white text-purple-900 rounded-2xl text-xl font-bold hover:bg-gray-100 transition-colors"
+        >
+          {gameOver ? 'Play Again' : 'Start Game'}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center min-h-screen bg-gradient-to-b from-indigo-900 to-purple-900 text-white p-4">
+      <div className="flex justify-between w-full max-w-md mb-4">
+        <span className="text-lg">Score: {score}</span>
+        <span className="text-lg">{'❤️'.repeat(lives)}</span>
+      </div>
+
+      <div className="w-full max-w-md bg-gray-800 rounded-full h-2 mb-6">
+        <div
+          className="h-2 rounded-full transition-all duration-100"
+          style={{ width: `${timeLeft}%`, backgroundColor: timeLeft > 30 ? '#22c55e' : '#ef4444' }}
+        />
+      </div>
+
+      <div className="text-center mb-8">
+        <p className="text-sm text-gray-400 mb-1">Tap the color:</p>
+        <p className="text-3xl font-bold" style={{ color: targetColor.hex }}>
+          {targetColor.name}
+        </p>
+      </div>
+
+      {feedback && (
+        <p className={`text-xl font-bold mb-4 ${feedback === 'Correct!' ? 'text-green-400' : 'text-red-400'}`}>
+          {feedback}
+        </p>
+      )}
+
+      <div className="grid grid-cols-2 gap-4 w-full max-w-xs">
+        {options.map((color, i) => (
+          <button
+            key={`${color.name}-${i}`}
+            onClick={() => handleTap(color)}
+            className="w-full aspect-square rounded-full border-4 border-white/20 hover:scale-105 transition-transform active:scale-95"
+            style={{ backgroundColor: color.hex }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ColorTapGame;

--- a/src/artifacts/example-color-tap.tsx
+++ b/src/artifacts/example-color-tap.tsx
@@ -1,0 +1,180 @@
+import React, { useState, useEffect, useCallback } from 'react';
+
+/**
+ * Color Tap - Example Claude AI Artifact
+ *
+ * A simple color-matching tap game. Tap the circle that matches the
+ * color name displayed at the top. Score points for correct taps,
+ * and the game speeds up as you progress.
+ *
+ * This artifact demonstrates the RNBridge integration:
+ *   window.RNBridge.sendScore(score)
+ *   window.RNBridge.gameOver(finalScore)
+ */
+
+interface ColorOption {
+  name: string;
+  hex: string;
+}
+
+const COLORS: ColorOption[] = [
+  { name: 'Red', hex: '#ef4444' },
+  { name: 'Blue', hex: '#3b82f6' },
+  { name: 'Green', hex: '#22c55e' },
+  { name: 'Yellow', hex: '#eab308' },
+  { name: 'Purple', hex: '#a855f7' },
+  { name: 'Orange', hex: '#f97316' },
+];
+
+function shuffleArray<T>(array: T[]): T[] {
+  const shuffled = [...array];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+}
+
+const ColorTapGame: React.FC = () => {
+  const [score, setScore] = useState(0);
+  const [lives, setLives] = useState(3);
+  const [targetColor, setTargetColor] = useState<ColorOption>(COLORS[0]);
+  const [options, setOptions] = useState<ColorOption[]>([]);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [gameStarted, setGameStarted] = useState(false);
+  const [gameOver, setGameOver] = useState(false);
+  const [timeLeft, setTimeLeft] = useState(100);
+
+  const pickNewRound = useCallback(() => {
+    const target = COLORS[Math.floor(Math.random() * COLORS.length)];
+    const others = COLORS.filter((c) => c.name !== target.name);
+    const picked = shuffleArray(others).slice(0, 3);
+    const allOptions = shuffleArray([target, ...picked]);
+    setTargetColor(target);
+    setOptions(allOptions);
+    setTimeLeft(100);
+  }, []);
+
+  const startGame = () => {
+    setScore(0);
+    setLives(3);
+    setGameOver(false);
+    setGameStarted(true);
+    setFeedback(null);
+    pickNewRound();
+  };
+
+  useEffect(() => {
+    if (!gameStarted || gameOver) return;
+
+    const timer = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 0) {
+          setLives((l) => {
+            const newLives = l - 1;
+            if (newLives <= 0) {
+              setGameOver(true);
+              if (window.RNBridge) window.RNBridge.gameOver(score);
+            }
+            return newLives;
+          });
+          pickNewRound();
+          return 100;
+        }
+        return prev - 2;
+      });
+    }, 100);
+
+    return () => clearInterval(timer);
+  }, [gameStarted, gameOver, pickNewRound, score]);
+
+  const handleTap = (color: ColorOption) => {
+    if (gameOver) return;
+
+    if (color.name === targetColor.name) {
+      const newScore = score + 10;
+      setScore(newScore);
+      setFeedback('Correct!');
+      if (window.RNBridge) window.RNBridge.sendScore(newScore);
+    } else {
+      setFeedback('Wrong!');
+      const newLives = lives - 1;
+      setLives(newLives);
+      if (newLives <= 0) {
+        setGameOver(true);
+        if (window.RNBridge) window.RNBridge.gameOver(score);
+        return;
+      }
+    }
+
+    setTimeout(() => setFeedback(null), 400);
+    pickNewRound();
+  };
+
+  if (!gameStarted || gameOver) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-b from-indigo-900 to-purple-900 text-white">
+        <h1 className="text-4xl font-bold mb-4">Color Tap</h1>
+        {gameOver && (
+          <div className="text-center mb-6">
+            <p className="text-xl mb-2">Game Over!</p>
+            <p className="text-3xl font-bold text-yellow-300">Score: {score}</p>
+          </div>
+        )}
+        {!gameOver && (
+          <p className="text-lg text-gray-300 mb-6 text-center px-8">
+            Tap the circle that matches the color name!
+          </p>
+        )}
+        <button
+          onClick={startGame}
+          className="px-8 py-4 bg-white text-purple-900 rounded-2xl text-xl font-bold hover:bg-gray-100 transition-colors"
+        >
+          {gameOver ? 'Play Again' : 'Start Game'}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center min-h-screen bg-gradient-to-b from-indigo-900 to-purple-900 text-white p-4">
+      <div className="flex justify-between w-full max-w-md mb-4">
+        <span className="text-lg">Score: {score}</span>
+        <span className="text-lg">{'❤️'.repeat(lives)}</span>
+      </div>
+
+      <div className="w-full max-w-md bg-gray-800 rounded-full h-2 mb-6">
+        <div
+          className="h-2 rounded-full transition-all duration-100"
+          style={{ width: `${timeLeft}%`, backgroundColor: timeLeft > 30 ? '#22c55e' : '#ef4444' }}
+        />
+      </div>
+
+      <div className="text-center mb-8">
+        <p className="text-sm text-gray-400 mb-1">Tap the color:</p>
+        <p className="text-3xl font-bold" style={{ color: targetColor.hex }}>
+          {targetColor.name}
+        </p>
+      </div>
+
+      {feedback && (
+        <p className={`text-xl font-bold mb-4 ${feedback === 'Correct!' ? 'text-green-400' : 'text-red-400'}`}>
+          {feedback}
+        </p>
+      )}
+
+      <div className="grid grid-cols-2 gap-4 w-full max-w-xs">
+        {options.map((color, i) => (
+          <button
+            key={`${color.name}-${i}`}
+            onClick={() => handleTap(color)}
+            className="w-full aspect-square rounded-full border-4 border-white/20 hover:scale-105 transition-transform active:scale-95"
+            style={{ backgroundColor: color.hex }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ColorTapGame;

--- a/src/components/ArtifactGameAdapter.tsx
+++ b/src/components/ArtifactGameAdapter.tsx
@@ -1,0 +1,141 @@
+import React, { useRef, useCallback } from 'react';
+import { View, StyleSheet, Platform } from 'react-native';
+import { WebView, WebViewMessageEvent } from 'react-native-webview';
+
+/**
+ * Message types sent from the artifact WebView to React Native.
+ *
+ * - scoreUpdate: The artifact reports a new score
+ * - gameOver:    The artifact signals the game has ended
+ * - navigate:    The artifact requests navigation (e.g. "back")
+ * - ready:       The artifact has finished loading
+ * - custom:      Arbitrary payload for game-specific communication
+ */
+export interface ArtifactMessage {
+  type: 'scoreUpdate' | 'gameOver' | 'navigate' | 'ready' | 'custom';
+  payload?: Record<string, unknown>;
+}
+
+interface ArtifactGameAdapterProps {
+  /** Complete HTML string containing the artifact game */
+  htmlContent: string;
+  /** Called when the artifact sends a message to React Native */
+  onMessage?: (message: ArtifactMessage) => void;
+  /** Called when the game reports a score update */
+  onScoreUpdate?: (score: number) => void;
+  /** Called when the game signals game-over */
+  onGameOver?: (finalScore: number) => void;
+  /** Called when the artifact requests navigation (e.g. "back") */
+  onNavigate?: (target: string) => void;
+}
+
+/**
+ * Renders a Claude AI Artifact (.tsx) inside a WebView.
+ *
+ * The artifact is compiled to a self-contained HTML document that includes
+ * React and ReactDOM from CDN, plus an optional Tailwind CSS build.
+ * Communication between the artifact and React Native happens via
+ * postMessage / onMessage bridge.
+ *
+ * Usage:
+ * ```tsx
+ * <ArtifactGameAdapter
+ *   htmlContent={myGameHtml}
+ *   onScoreUpdate={(score) => updateBestScore(score)}
+ *   onGameOver={(finalScore) => showGameOverOverlay(finalScore)}
+ *   onNavigate={(target) => { if (target === 'back') navigation.goBack(); }}
+ * />
+ * ```
+ */
+export const ArtifactGameAdapter: React.FC<ArtifactGameAdapterProps> = ({
+  htmlContent,
+  onMessage,
+  onScoreUpdate,
+  onGameOver,
+  onNavigate,
+}) => {
+  const webViewRef = useRef<WebView>(null);
+
+  const handleMessage = useCallback(
+    (event: WebViewMessageEvent) => {
+      try {
+        const message: ArtifactMessage = JSON.parse(event.nativeEvent.data);
+
+        onMessage?.(message);
+
+        switch (message.type) {
+          case 'scoreUpdate':
+            if (typeof message.payload?.score === 'number') {
+              onScoreUpdate?.(message.payload.score as number);
+            }
+            break;
+          case 'gameOver':
+            onGameOver?.((message.payload?.finalScore as number) ?? 0);
+            break;
+          case 'navigate':
+            onNavigate?.((message.payload?.target as string) ?? 'back');
+            break;
+        }
+      } catch {
+        // Ignore malformed messages
+      }
+    },
+    [onMessage, onScoreUpdate, onGameOver, onNavigate],
+  );
+
+  /**
+   * Send a message from React Native into the artifact WebView.
+   * The artifact can listen with: window.addEventListener('message', handler)
+   */
+  const sendToArtifact = useCallback((message: Record<string, unknown>) => {
+    webViewRef.current?.injectJavaScript(`
+      window.dispatchEvent(new MessageEvent('message', {
+        data: ${JSON.stringify(JSON.stringify(message))}
+      }));
+      true;
+    `);
+  }, []);
+
+  // On web platform, render artifact in an iframe instead
+  if (Platform.OS === 'web') {
+    return (
+      <View style={styles.container}>
+        <iframe
+          srcDoc={htmlContent}
+          style={{ flex: 1, border: 'none', width: '100%', height: '100%' } as never}
+          sandbox="allow-scripts allow-same-origin"
+        />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <WebView
+        ref={webViewRef}
+        source={{ html: htmlContent }}
+        style={styles.webView}
+        onMessage={handleMessage}
+        javaScriptEnabled
+        domStorageEnabled
+        startInLoadingState={false}
+        originWhitelist={['*']}
+        scrollEnabled={false}
+        bounces={false}
+        overScrollMode="never"
+        setBuiltInZoomControls={false}
+        setDisplayZoomControls={false}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  webView: {
+    flex: 1,
+    backgroundColor: 'transparent',
+  },
+});

--- a/src/context/ColorTapContext.tsx
+++ b/src/context/ColorTapContext.tsx
@@ -1,0 +1,53 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useAuth } from './AuthContext';
+
+const STORAGE_KEY = '@game_color-tap_best_score';
+
+interface ColorTapContextType {
+  bestScore: number;
+  updateBestScore: (score: number) => void;
+}
+
+const ColorTapContext = createContext<ColorTapContextType | null>(null);
+
+export const ColorTapProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { user, isGuest } = useAuth();
+  const userId = user?.id || (isGuest ? 'guest' : 'guest');
+  const [bestScore, setBestScore] = useState(0);
+
+  useEffect(() => {
+    const loadScore = async () => {
+      try {
+        const stored = await AsyncStorage.getItem(`${STORAGE_KEY}:${userId}`);
+        if (stored !== null) {
+          setBestScore(Number(stored));
+        }
+      } catch {
+        // Ignore storage errors
+      }
+    };
+    loadScore();
+  }, [userId]);
+
+  const updateBestScore = (score: number) => {
+    if (score > bestScore) {
+      setBestScore(score);
+      AsyncStorage.setItem(`${STORAGE_KEY}:${userId}`, String(score)).catch(() => {});
+    }
+  };
+
+  return (
+    <ColorTapContext.Provider value={{ bestScore, updateBestScore }}>
+      {children}
+    </ColorTapContext.Provider>
+  );
+};
+
+export const useColorTap = () => {
+  const ctx = useContext(ColorTapContext);
+  if (!ctx) {
+    throw new Error('useColorTap must be used within ColorTapProvider');
+  }
+  return ctx;
+};

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -233,6 +233,10 @@
     "petRunner": {
       "name": "Pet Runner",
       "description": "Run, jump and collect coins!"
+    },
+    "colorTap": {
+      "name": "Color Tap",
+      "description": "Tap the matching color!"
     }
   },
   "muito": {
@@ -282,6 +286,20 @@
       "title": "Game Over!",
       "distance": "Distance",
       "coins": "Coins",
+      "score": "Score",
+      "newBest": "New Best!",
+      "playAgain": "Play Again"
+    }
+  },
+  "colorTap": {
+    "title": "Color Tap",
+    "subtitle": "Tap the matching color!",
+    "instructions": "Play Color Tap and try to beat your best score!",
+    "play": "Play!",
+    "bestScore": "Best Score",
+    "score": "Score",
+    "gameOver": {
+      "title": "Game Over!",
       "score": "Score",
       "newBest": "New Best!",
       "playAgain": "Play Again"

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -20,7 +20,6 @@
     "createPetHint": "Começar um novo jogo com um novo pet",
     "deletePet": "Excluir Pet 🗑️",
     "deletePetHint": "Remover permanentemente seu pet atual",
-
     "createPetModal": {
       "title": "Criar Novo Pet",
       "message": "Tem certeza? Seu pet \"{{name}}\" será removido permanentemente.",
@@ -234,6 +233,10 @@
     "petRunner": {
       "name": "Pet Corredor",
       "description": "Corra, pule e colete moedas!"
+    },
+    "colorTap": {
+      "name": "Color Tap",
+      "description": "Tap the matching color!"
     }
   },
   "muito": {
@@ -286,6 +289,20 @@
       "score": "Pontuação",
       "newBest": "Novo Recorde!",
       "playAgain": "Jogar Novamente"
+    }
+  },
+  "colorTap": {
+    "title": "Color Tap",
+    "subtitle": "Tap the matching color!",
+    "instructions": "Play Color Tap and try to beat your best score!",
+    "play": "Play!",
+    "bestScore": "Best Score",
+    "score": "Score",
+    "gameOver": {
+      "title": "Game Over!",
+      "score": "Score",
+      "newBest": "New Best!",
+      "playAgain": "Play Again"
     }
   }
 }

--- a/src/screens/ColorTapGameScreen.tsx
+++ b/src/screens/ColorTapGameScreen.tsx
@@ -1,0 +1,374 @@
+import React, { useState, useCallback } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../types/navigation';
+import { ArtifactGameAdapter, ArtifactMessage } from '../components/ArtifactGameAdapter';
+import { useColorTap } from '../context/ColorTapContext';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ColorTapGame'>;
+
+/**
+ * HTML content generated from the Claude AI Artifact.
+ * Original component name: ColorTapGame
+ *
+ * The artifact communicates with React Native via window.RNBridge:
+ *   window.RNBridge.sendScore(score)   - report score updates
+ *   window.RNBridge.gameOver(score)    - signal game over
+ *   window.RNBridge.navigate('back')   - request navigation back
+ */
+const ARTIFACT_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>ColorTap</title>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"><\/script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"><\/script>
+  <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"><\/script>
+  <script src="https://cdn.tailwindcss.com"><\/script>
+  <script>
+    window.RNBridge = {
+      send: function(message) {
+        if (window.ReactNativeWebView) {
+          window.ReactNativeWebView.postMessage(JSON.stringify(message));
+        } else if (window.parent !== window) {
+          window.parent.postMessage(JSON.stringify(message), '*');
+        }
+      },
+      sendScore: function(score) { this.send({ type: 'scoreUpdate', payload: { score: score } }); },
+      gameOver: function(finalScore) { this.send({ type: 'gameOver', payload: { finalScore: finalScore } }); },
+      navigate: function(target) { this.send({ type: 'navigate', payload: { target: target || 'back' } }); }
+    };
+  <\/script>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body, #root { width: 100%; height: 100%; overflow: hidden; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    const { useState, useEffect, useCallback, useRef, useMemo, useReducer, useContext, createContext } = React;
+
+    /**
+ * Color Tap - Example Claude AI Artifact
+ *
+ * A simple color-matching tap game. Tap the circle that matches the
+ * color name displayed at the top. Score points for correct taps,
+ * and the game speeds up as you progress.
+ *
+ * This artifact demonstrates the RNBridge integration:
+ *   window.RNBridge.sendScore(score)
+ *   window.RNBridge.gameOver(finalScore)
+ */
+
+
+const COLORS: ColorOption[] = [
+  { name: 'Red', hex: '#ef4444' },
+  { name: 'Blue', hex: '#3b82f6' },
+  { name: 'Green', hex: '#22c55e' },
+  { name: 'Yellow', hex: '#eab308' },
+  { name: 'Purple', hex: '#a855f7' },
+  { name: 'Orange', hex: '#f97316' },
+];
+
+function shuffleArray<T>(array: T[]): T[] {
+  const shuffled = [...array];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+}
+
+const ColorTapGame = () => {
+  const [score, setScore] = useState(0);
+  const [lives, setLives] = useState(3);
+  const [targetColor, setTargetColor] = useState<ColorOption>(COLORS[0]);
+  const [options, setOptions] = useState<ColorOption[]>([]);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [gameStarted, setGameStarted] = useState(false);
+  const [gameOver, setGameOver] = useState(false);
+  const [timeLeft, setTimeLeft] = useState(100);
+
+  const pickNewRound = useCallback(() => {
+    const target = COLORS[Math.floor(Math.random() * COLORS.length)];
+    const others = COLORS.filter((c) => c.name !== target.name);
+    const picked = shuffleArray(others).slice(0, 3);
+    const allOptions = shuffleArray([target, ...picked]);
+    setTargetColor(target);
+    setOptions(allOptions);
+    setTimeLeft(100);
+  }, []);
+
+  const startGame = () => {
+    setScore(0);
+    setLives(3);
+    setGameOver(false);
+    setGameStarted(true);
+    setFeedback(null);
+    pickNewRound();
+  };
+
+  useEffect(() => {
+    if (!gameStarted || gameOver) return;
+
+    const timer = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 0) {
+          setLives((l) => {
+            const newLives = l - 1;
+            if (newLives <= 0) {
+              setGameOver(true);
+              if (window.RNBridge) window.RNBridge.gameOver(score);
+            }
+            return newLives;
+          });
+          pickNewRound();
+          return 100;
+        }
+        return prev - 2;
+      });
+    }, 100);
+
+    return () => clearInterval(timer);
+  }, [gameStarted, gameOver, pickNewRound, score]);
+
+  const handleTap = (color: ColorOption) => {
+    if (gameOver) return;
+
+    if (color.name === targetColor.name) {
+      const newScore = score + 10;
+      setScore(newScore);
+      setFeedback('Correct!');
+      if (window.RNBridge) window.RNBridge.sendScore(newScore);
+    } else {
+      setFeedback('Wrong!');
+      const newLives = lives - 1;
+      setLives(newLives);
+      if (newLives <= 0) {
+        setGameOver(true);
+        if (window.RNBridge) window.RNBridge.gameOver(score);
+        return;
+      }
+    }
+
+    setTimeout(() => setFeedback(null), 400);
+    pickNewRound();
+  };
+
+  if (!gameStarted || gameOver) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen bg-gradient-to-b from-indigo-900 to-purple-900 text-white">
+        <h1 className="text-4xl font-bold mb-4">Color Tap</h1>
+        {gameOver && (
+          <div className="text-center mb-6">
+            <p className="text-xl mb-2">Game Over!</p>
+            <p className="text-3xl font-bold text-yellow-300">Score: {score}</p>
+          </div>
+        )}
+        {!gameOver && (
+          <p className="text-lg text-gray-300 mb-6 text-center px-8">
+            Tap the circle that matches the color name!
+          </p>
+        )}
+        <button
+          onClick={startGame}
+          className="px-8 py-4 bg-white text-purple-900 rounded-2xl text-xl font-bold hover:bg-gray-100 transition-colors"
+        >
+          {gameOver ? 'Play Again' : 'Start Game'}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center min-h-screen bg-gradient-to-b from-indigo-900 to-purple-900 text-white p-4">
+      <div className="flex justify-between w-full max-w-md mb-4">
+        <span className="text-lg">Score: {score}</span>
+        <span className="text-lg">{'❤️'.repeat(lives)}</span>
+      </div>
+
+      <div className="w-full max-w-md bg-gray-800 rounded-full h-2 mb-6">
+        <div
+          className="h-2 rounded-full transition-all duration-100"
+          style={{ width: \`\${timeLeft}%\`, backgroundColor: timeLeft > 30 ? '#22c55e' : '#ef4444' }}
+        />
+      </div>
+
+      <div className="text-center mb-8">
+        <p className="text-sm text-gray-400 mb-1">Tap the color:</p>
+        <p className="text-3xl font-bold" style={{ color: targetColor.hex }}>
+          {targetColor.name}
+        </p>
+      </div>
+
+      {feedback && (
+        <p className={\`text-xl font-bold mb-4 \${feedback === 'Correct!' ? 'text-green-400' : 'text-red-400'}\`}>
+          {feedback}
+        </p>
+      )}
+
+      <div className="grid grid-cols-2 gap-4 w-full max-w-xs">
+        {options.map((color, i) => (
+          <button
+            key={\`\${color.name}-\${i}\`}
+            onClick={() => handleTap(color)}
+            className="w-full aspect-square rounded-full border-4 border-white/20 hover:scale-105 transition-transform active:scale-95"
+            style={{ backgroundColor: color.hex }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+ColorTapGame;
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(React.createElement(ColorTapGame));
+  <\/script>
+</body>
+</html>`;
+
+export const ColorTapGameScreen: React.FC<Props> = ({ navigation }) => {
+  const { t } = useTranslation();
+  const { updateBestScore } = useColorTap();
+  const [score, setScore] = useState(0);
+  const [gameOver, setGameOver] = useState(false);
+
+  const handleScoreUpdate = useCallback(
+    (newScore: number) => {
+      setScore(newScore);
+    },
+    [],
+  );
+
+  const handleGameOver = useCallback(
+    (finalScore: number) => {
+      setScore(finalScore);
+      setGameOver(true);
+      updateBestScore(finalScore);
+    },
+    [updateBestScore],
+  );
+
+  const handleNavigate = useCallback(
+    (target: string) => {
+      if (target === 'back') {
+        navigation.goBack();
+      }
+    },
+    [navigation],
+  );
+
+  const handleBack = () => {
+    navigation.goBack();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={handleBack} accessibilityRole="button">
+          <Text style={styles.backText}>{t('common.back')}</Text>
+        </TouchableOpacity>
+        {score > 0 && <Text style={styles.scoreText}>{score}</Text>}
+      </View>
+
+      <View style={styles.gameArea}>
+        <ArtifactGameAdapter
+          htmlContent={ARTIFACT_HTML}
+          onScoreUpdate={handleScoreUpdate}
+          onGameOver={handleGameOver}
+          onNavigate={handleNavigate}
+        />
+      </View>
+
+      {gameOver && (
+        <View style={styles.overlay}>
+          <View style={styles.overlayCard}>
+            <Text style={styles.overlayTitle}>{t('colorTap.gameOver.title')}</Text>
+            <Text style={styles.overlayScore}>{score}</Text>
+            <TouchableOpacity
+              style={styles.playAgainButton}
+              onPress={() => {
+                setGameOver(false);
+                setScore(0);
+                // Force re-mount the WebView by navigating away and back
+                navigation.replace('ColorTapGame');
+              }}
+              accessibilityRole="button"
+            >
+              <Text style={styles.playAgainText}>{t('colorTap.gameOver.playAgain')}</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f0ff',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  backText: {
+    fontSize: 16,
+    color: '#9b59b6',
+    fontWeight: '600',
+  },
+  scoreText: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: '#333',
+  },
+  gameArea: {
+    flex: 1,
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  overlayCard: {
+    backgroundColor: '#fff',
+    borderRadius: 24,
+    padding: 32,
+    alignItems: 'center',
+    minWidth: 260,
+  },
+  overlayTitle: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#333',
+    marginBottom: 12,
+  },
+  overlayScore: {
+    fontSize: 40,
+    fontWeight: '800',
+    color: '#9b59b6',
+    marginBottom: 24,
+  },
+  playAgainButton: {
+    backgroundColor: '#9b59b6',
+    borderRadius: 16,
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+  },
+  playAgainText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+});

--- a/src/screens/ColorTapHomeScreen.tsx
+++ b/src/screens/ColorTapHomeScreen.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { ScreenNavigationProp } from '../types/navigation';
+import { useColorTap } from '../context/ColorTapContext';
+
+type Props = {
+  navigation: ScreenNavigationProp<'ColorTapHome'>;
+};
+
+export const ColorTapHomeScreen: React.FC<Props> = ({ navigation }) => {
+  const { t } = useTranslation();
+  const { bestScore } = useColorTap();
+
+  const handlePlay = () => {
+    navigation.navigate('ColorTapGame');
+  };
+
+  const handleBack = () => {
+    navigation.getParent()?.goBack();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <TouchableOpacity style={styles.backButton} onPress={handleBack} accessibilityRole="button">
+        <Text style={styles.backText}>{t('common.back')}</Text>
+      </TouchableOpacity>
+
+      <View style={styles.content}>
+        <Text style={styles.title}>{t('colorTap.title')}</Text>
+        <Text style={styles.subtitle}>{t('colorTap.subtitle')}</Text>
+        <Text style={styles.instructions}>{t('colorTap.instructions')}</Text>
+
+        {bestScore > 0 && (
+          <View style={styles.scoreCard}>
+            <Text style={styles.scoreLabel}>{t('colorTap.bestScore')}</Text>
+            <Text style={styles.scoreValue}>{bestScore}</Text>
+          </View>
+        )}
+
+        <TouchableOpacity style={styles.playButton} onPress={handlePlay} accessibilityRole="button">
+          <Text style={styles.playText}>{t('colorTap.play')}</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f0ff',
+  },
+  backButton: {
+    padding: 16,
+    alignSelf: 'flex-start',
+  },
+  backText: {
+    fontSize: 16,
+    color: '#9b59b6',
+    fontWeight: '600',
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 32,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: '800',
+    color: '#9b59b6',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#666',
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  instructions: {
+    fontSize: 14,
+    color: '#888',
+    textAlign: 'center',
+    marginBottom: 32,
+    lineHeight: 20,
+  },
+  scoreCard: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 32,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 8,
+    elevation: 3,
+    minWidth: 140,
+  },
+  scoreLabel: {
+    fontSize: 14,
+    color: '#888',
+    marginBottom: 4,
+  },
+  scoreValue: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: '#9b59b6',
+  },
+  playButton: {
+    backgroundColor: '#9b59b6',
+    borderRadius: 20,
+    paddingVertical: 16,
+    paddingHorizontal: 48,
+  },
+  playText: {
+    color: '#fff',
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+});

--- a/src/screens/ColorTapNavigator.tsx
+++ b/src/screens/ColorTapNavigator.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../types/navigation';
+import { ColorTapHomeScreen } from './ColorTapHomeScreen';
+import { ColorTapGameScreen } from './ColorTapGameScreen';
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export const ColorTapNavigator: React.FC = () => (
+  <Stack.Navigator
+    initialRouteName="ColorTapHome"
+    screenOptions={{ headerShown: false, animation: 'slide_from_right' }}
+  >
+    <Stack.Screen name="ColorTapHome" component={ColorTapHomeScreen} />
+    <Stack.Screen name="ColorTapGame" component={ColorTapGameScreen} />
+  </Stack.Navigator>
+);

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -50,6 +50,10 @@ export type RootStackParamList = {
   PetRunnerHome: undefined;
   /** Pet Runner game screen */
   PetRunnerGame: undefined;
+  /** ColorTap home screen */
+  ColorTapHome: undefined;
+  /** ColorTap game screen */
+  ColorTapGame: undefined;
 };
 
 /**
@@ -58,8 +62,8 @@ export type RootStackParamList = {
  * Usage:
  * ```typescript
  * const navigation = useNavigation<RootNavigationProp>();
- * navigation.navigate('Home'); // ✓ Type-safe
- * navigation.navigate('InvalidRoute'); // ✗ TypeScript error
+ * navigation.navigate('Home'); // Type-safe
+ * navigation.navigate('InvalidRoute'); // TypeScript error
  * ```
  */
 export type RootNavigationProp = NativeStackNavigationProp<RootStackParamList>;

--- a/src/utils/artifactHtml.ts
+++ b/src/utils/artifactHtml.ts
@@ -1,0 +1,184 @@
+/**
+ * Converts a Claude AI Artifact (.tsx source code) into a self-contained
+ * HTML document that can be rendered in a WebView.
+ *
+ * The generated HTML includes:
+ * - React 18 + ReactDOM from CDN
+ * - Tailwind CSS (many Claude Artifacts use it)
+ * - A postMessage bridge so the artifact can communicate with React Native
+ * - Viewport meta tag for proper mobile scaling
+ *
+ * The artifact code is compiled at runtime via Babel Standalone so JSX works
+ * directly without a build step.
+ */
+
+/**
+ * Bridge script injected into every artifact HTML document.
+ * Provides `window.RNBridge` for artifact → React Native communication.
+ *
+ * Artifacts can call:
+ *   window.RNBridge.sendScore(score)
+ *   window.RNBridge.gameOver(finalScore)
+ *   window.RNBridge.navigate('back')
+ *   window.RNBridge.send({ type: 'custom', payload: {...} })
+ */
+const BRIDGE_SCRIPT = `
+<script>
+  window.RNBridge = {
+    send: function(message) {
+      if (window.ReactNativeWebView) {
+        window.ReactNativeWebView.postMessage(JSON.stringify(message));
+      } else if (window.parent !== window) {
+        window.parent.postMessage(JSON.stringify(message), '*');
+      }
+    },
+    sendScore: function(score) {
+      this.send({ type: 'scoreUpdate', payload: { score: score } });
+    },
+    gameOver: function(finalScore) {
+      this.send({ type: 'gameOver', payload: { finalScore: finalScore } });
+    },
+    navigate: function(target) {
+      this.send({ type: 'navigate', payload: { target: target || 'back' } });
+    }
+  };
+
+  // Signal that the artifact is ready
+  window.addEventListener('DOMContentLoaded', function() {
+    setTimeout(function() {
+      window.RNBridge.send({ type: 'ready' });
+    }, 100);
+  });
+</script>
+`;
+
+/**
+ * Strips TypeScript / ES module syntax from artifact source code so it
+ * can run in a plain <script type="text/babel"> block.
+ *
+ * Handles:
+ * - import statements (React is available globally via CDN)
+ * - export default / export const statements
+ * - TypeScript type annotations in common patterns
+ */
+export function stripModuleSyntax(source: string): string {
+  let code = source;
+
+  // Remove import statements (React/ReactDOM are global via CDN)
+  code = code.replace(/^import\s+.*?(?:from\s+['"].*?['"])?;?\s*$/gm, '');
+
+  // Remove "export default" but keep the declaration
+  code = code.replace(/^export\s+default\s+/gm, '');
+
+  // Remove "export" keyword from named exports
+  code = code.replace(/^export\s+(?=(?:const|let|var|function|class|interface|type)\s)/gm, '');
+
+  // Remove TypeScript interface/type declarations (standalone blocks)
+  code = code.replace(/^(?:interface|type)\s+\w+(?:<[^>]*>)?\s*=?\s*\{[^}]*\};?\s*$/gm, '');
+  code = code.replace(/^type\s+\w+(?:<[^>]*>)?\s*=\s*[^;]+;\s*$/gm, '');
+
+  // Remove TypeScript type annotations from function parameters: (x: Type)
+  // This is intentionally conservative to avoid breaking code
+  code = code.replace(/:\s*React\.FC(?:<[^>]*>)?/g, '');
+
+  return code.trim();
+}
+
+/**
+ * Detects the main component name exported from the artifact source.
+ * Looks for patterns like:
+ *   - export default function GameName
+ *   - export default GameName
+ *   - const GameName = () =>
+ *   - function GameName()
+ */
+export function detectComponentName(source: string): string {
+  // "export default function ComponentName"
+  const defaultFnMatch = source.match(/export\s+default\s+function\s+(\w+)/);
+  if (defaultFnMatch) return defaultFnMatch[1];
+
+  // "export default ComponentName" (identifier reference)
+  const defaultIdMatch = source.match(/export\s+default\s+(\w+)\s*;/);
+  if (defaultIdMatch) return defaultIdMatch[1];
+
+  // Last "const ComponentName = " with arrow function or React.FC
+  const constMatches = [...source.matchAll(/(?:export\s+)?const\s+(\w+)\s*(?::\s*\w+(?:<[^>]*>)?\s*)?=\s*(?:\([^)]*\)\s*=>|\(\s*\)\s*=>|function)/g)];
+  if (constMatches.length > 0) {
+    // Prefer the last one (often the main component is defined last)
+    return constMatches[constMatches.length - 1][1];
+  }
+
+  // "function ComponentName" (standalone)
+  const fnMatches = [...source.matchAll(/^function\s+(\w+)/gm)];
+  if (fnMatches.length > 0) {
+    return fnMatches[fnMatches.length - 1][1];
+  }
+
+  return 'App';
+}
+
+/**
+ * Wraps artifact source code in a complete HTML document ready for WebView rendering.
+ *
+ * @param artifactSource - Raw .tsx source code from a Claude Artifact
+ * @param options - Optional configuration
+ * @returns Complete HTML string
+ */
+export function buildArtifactHtml(
+  artifactSource: string,
+  options?: {
+    /** Override the detected component name */
+    componentName?: string;
+    /** Include Tailwind CSS (default: true) */
+    includeTailwind?: boolean;
+    /** Additional CSS to inject */
+    extraCss?: string;
+    /** Additional scripts to inject (before artifact code) */
+    extraScripts?: string;
+  },
+): string {
+  const {
+    componentName = detectComponentName(artifactSource),
+    includeTailwind = true,
+    extraCss = '',
+    extraScripts = '',
+  } = options ?? {};
+
+  const strippedCode = stripModuleSyntax(artifactSource);
+
+  const tailwindTag = includeTailwind
+    ? '<script src="https://cdn.tailwindcss.com"></script>'
+    : '';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>Game</title>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  ${tailwindTag}
+  ${BRIDGE_SCRIPT}
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body, #root { width: 100%; height: 100%; overflow: hidden; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
+    ${extraCss}
+  </style>
+  ${extraScripts}
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    const { useState, useEffect, useCallback, useRef, useMemo, useReducer, useContext, createContext } = React;
+
+    ${strippedCode}
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(React.createElement(${componentName}));
+  </script>
+</body>
+</html>`;
+}


### PR DESCRIPTION
## Summary

This PR introduces a new **ColorTap** game to the game library and establishes a comprehensive **game creation system** that allows developers to scaffold new games from Claude AI Artifacts with a single command.

## Key Changes

### New Game: ColorTap
- Added `ColorTapNavigator`, `ColorTapContext`, `ColorTapHomeScreen`, and `ColorTapGameScreen`
- Implemented a color-matching tap game where players identify colors by name
- Integrated score tracking and best score persistence via context
- Game automatically appears in the game selection screen with 🎨 emoji

### Game Creation System (`scripts/create-game.js`)
- **Interactive CLI tool** that scaffolds complete game structure from Claude AI Artifacts
- Generates 4 core files automatically:
  - Navigator (screen stack setup)
  - Context (state management & score persistence)
  - HomeScreen (game intro & best score display)
  - GameScreen (game wrapper with WebView adapter)
- **Automatic file updates**:
  - Registers game in `App.tsx`
  - Updates navigation types
  - Adds i18n keys to locale files (en.json, pt-BR.json)
- **RNBridge integration**: Artifacts communicate with React Native via `window.RNBridge` for score updates and navigation
- Supports both interactive and non-interactive (flag-based) modes

### Infrastructure Updates
- Added `react-native-webview` (v13.8.6) dependency for artifact rendering
- Created mock for `react-native-webview` in Jest config
- Updated Jest `transformIgnorePatterns` to handle webview module
- Added `create-game` npm script for easy access

### Example Artifacts
- Included `color-tap.tsx` and `example-color-tap.tsx` as reference implementations
- Demonstrates RNBridge API usage for score reporting and game-over handling

## Implementation Details

- **Artifact Processing**: The system strips TypeScript/ES module syntax from artifacts and embeds them in an HTML template with React 18 UMD builds and Tailwind CSS
- **Score Persistence**: Uses AsyncStorage with user-specific keys to track best scores per game
- **Navigation**: Seamlessly integrates new games into the existing game registry and navigation stack
- **i18n Ready**: All generated games include localization keys for English and Portuguese

## Usage

```bash
# Interactive mode
node scripts/create-game.js

# Non-interactive mode
node scripts/create-game.js --artifact path/to/artifact.tsx --name "Game Name" --id game-id --emoji "🎮" --category casual
```

The generated game immediately appears in the game selection screen after running `pnpm start`.

https://claude.ai/code/session_01XmoRQNeuJKgpJkzgXx9D3p