### PR TITLE
Add back button to multiplayer game screen and improve navigation

### DIFF
--- a/src/components/ScreenHeader.tsx
+++ b/src/components/ScreenHeader.tsx
@@ -15,9 +15,9 @@ export const ScreenHeader: React.FC<ScreenHeaderProps> = ({
   return (
     <View style={styles.header}>
       <View style={styles.leftSection}>
-        {onBackPress && BackButtonIcon && (
+        {onBackPress && (
           <TouchableOpacity onPress={onBackPress} style={styles.backButton}>
-            <BackButtonIcon />
+            {BackButtonIcon && <BackButtonIcon />}
             <Text style={styles.backButtonText}>Voltar</Text>
           </TouchableOpacity>
         )}

--- a/src/screens/ColorTapHomeScreen.tsx
+++ b/src/screens/ColorTapHomeScreen.tsx
@@ -17,7 +17,11 @@ export const ColorTapHomeScreen: React.FC<Props> = ({ navigation }) => {
   };
 
   const handleBack = () => {
-    navigation.getParent()?.goBack();
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+    } else {
+      navigation.getParent()?.goBack();
+    }
   };
 
   return (

--- a/src/screens/MenuScreen.tsx
+++ b/src/screens/MenuScreen.tsx
@@ -99,7 +99,13 @@ export const MenuScreen: React.FC<Props> = ({ navigation }) => {
         {/* Back Button */}
         <TouchableOpacity
           style={styles.backButton}
-          onPress={() => navigation.navigate('GameSelection')}
+          onPress={() => {
+            if (navigation.canGoBack()) {
+              navigation.goBack();
+            } else {
+              navigation.getParent()?.goBack();
+            }
+          }}
           accessibilityRole="button"
           accessibilityLabel="Back to games"
         >

--- a/src/screens/MuitoMultiGameScreen.tsx
+++ b/src/screens/MuitoMultiGameScreen.tsx
@@ -24,6 +24,7 @@ export const MuitoMultiGameScreen: React.FC<Props> = ({ navigation }) => {
     roundStartedAt,
     opponentDisconnected,
     submitAnswer,
+    leaveRoom,
   } = useMultiPlayerMuito();
 
   const myUserId = user?.id || (isGuest ? 'guest' : 'guest');
@@ -77,10 +78,24 @@ export const MuitoMultiGameScreen: React.FC<Props> = ({ navigation }) => {
     [selectedAnswer, lastRoundResult, submitAnswer]
   );
 
+  const handleBack = () => {
+    leaveRoom();
+    navigation.goBack();
+  };
+
   // ── loading / waiting ────────────────────────────────────────────
   if (!puzzle) {
     return (
       <SafeAreaView style={styles.container}>
+        <View style={styles.waitingHeader}>
+          <TouchableOpacity
+            onPress={handleBack}
+            accessibilityRole="button"
+            accessibilityLabel={t('common.back')}
+          >
+            <Text style={styles.backText}>{t('common.back')}</Text>
+          </TouchableOpacity>
+        </View>
         <View style={styles.centerContent}>
           <Text style={styles.waitingText}>{t('muito.multiplayer.waitingForRound')}</Text>
         </View>
@@ -94,8 +109,15 @@ export const MuitoMultiGameScreen: React.FC<Props> = ({ navigation }) => {
 
   return (
     <SafeAreaView style={styles.container}>
-      {/* header: round counter + timer */}
+      {/* header: back button + round counter + timer */}
       <View style={styles.header}>
+        <TouchableOpacity
+          onPress={handleBack}
+          accessibilityRole="button"
+          accessibilityLabel={t('common.back')}
+        >
+          <Text style={styles.backText}>{t('common.back')}</Text>
+        </TouchableOpacity>
         <Text style={styles.roundText}>
           {t('muito.multiplayer.round', { current: currentRound, total: totalRounds })}
         </Text>
@@ -204,6 +226,15 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  waitingHeader: {
+    paddingHorizontal: 20,
+    paddingTop: 16,
+  },
+  backText: {
+    fontSize: 16,
+    color: '#9b59b6',
+    fontWeight: '600',
   },
   waitingText: {
     fontSize: 18,


### PR DESCRIPTION
## Summary
This PR improves navigation handling across multiple screens by adding a back button to the multiplayer game screen and making navigation more robust by checking if navigation can go back before attempting to navigate.

## Key Changes
- **MuitoMultiGameScreen**: Added back button functionality that calls `leaveRoom()` before navigating back, ensuring proper cleanup when users exit a multiplayer game. The back button appears in both the waiting state and active game state.
- **MenuScreen & ColorTapHomeScreen**: Improved back button logic to check `canGoBack()` before calling `goBack()`, with fallback to parent navigation if needed. This prevents navigation errors in edge cases.
- **ScreenHeader**: Fixed conditional rendering to always show the back button when `onBackPress` is provided, regardless of whether `BackButtonIcon` exists. The icon is now conditionally rendered inside the button.

## Implementation Details
- The `leaveRoom()` hook from `useMultiPlayerMuito()` is now properly called when users leave a multiplayer game, ensuring the room is cleaned up on the backend.
- Added new styles (`waitingHeader` and `backText`) to style the back button in the waiting state.
- Navigation safety checks prevent crashes when the navigation stack is in unexpected states.

https://claude.ai/code/session_012zexH8wf75bGpYEQG2oArv