### PR TITLE
Add localization strings for Memory Match and Pet Runner games

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -284,5 +284,43 @@
       "backToMenu": "Back to Menu",
       "opponentDisconnected": "Opponent disconnected"
     }
+  },
+  "memoryMatch": {
+    "title": "Memory Match",
+    "subtitle": "Find matching pairs!",
+    "instructions": "Tap cards to flip them and find matching pairs. Complete the board with fewer moves for a higher score!",
+    "play": "Play! 🎮",
+    "bestScore": "Best Score",
+    "moves": "Moves",
+    "matched": "matched",
+    "cardFaceDown": "Card face down",
+    "difficulty": {
+      "easy": "Easy",
+      "medium": "Medium",
+      "hard": "Hard"
+    },
+    "gameOver": {
+      "title": "Congratulations! 🎉",
+      "moves": "Moves",
+      "time": "Time",
+      "score": "Score",
+      "playAgain": "Play Again"
+    }
+  },
+  "petRunner": {
+    "title": "Pet Runner",
+    "subtitle": "Run, jump, collect!",
+    "instructions": "Tap to jump over obstacles and collect coins. How far can you go?",
+    "play": "Play! 🎮",
+    "bestScore": "Best Score",
+    "tapToStart": "Tap to Start",
+    "gameOver": {
+      "title": "Game Over",
+      "distance": "Distance",
+      "coins": "Coins",
+      "score": "Score",
+      "newBest": "⭐ New Best!",
+      "playAgain": "Play Again"
+    }
   }
 }

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -285,5 +285,43 @@
       "backToMenu": "Voltar ao Menu",
       "opponentDisconnected": "Oponente desconectou"
     }
+  },
+  "memoryMatch": {
+    "title": "Jogo da Memória",
+    "subtitle": "Encontre os pares!",
+    "instructions": "Toque nas cartas para virá-las e encontre os pares. Complete o tabuleiro com menos movimentos para uma pontuação maior!",
+    "play": "Jogar! 🎮",
+    "bestScore": "Melhor Pontuação",
+    "moves": "Movimentos",
+    "matched": "combinado",
+    "cardFaceDown": "Carta virada para baixo",
+    "difficulty": {
+      "easy": "Fácil",
+      "medium": "Médio",
+      "hard": "Difícil"
+    },
+    "gameOver": {
+      "title": "Parabéns! 🎉",
+      "moves": "Movimentos",
+      "time": "Tempo",
+      "score": "Pontuação",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "petRunner": {
+    "title": "Pet Corredor",
+    "subtitle": "Corra, pule, colete!",
+    "instructions": "Toque para pular os obstáculos e coletar moedas. Até onde você consegue ir?",
+    "play": "Jogar! 🎮",
+    "bestScore": "Melhor Pontuação",
+    "tapToStart": "Toque para Começar",
+    "gameOver": {
+      "title": "Fim de Jogo",
+      "distance": "Distância",
+      "coins": "Moedas",
+      "score": "Pontuação",
+      "newBest": "⭐ Novo Recorde!",
+      "playAgain": "Jogar Novamente"
+    }
   }
 }


### PR DESCRIPTION
## Summary
Added complete localization strings for two new games (Memory Match and Pet Runner) in both English and Brazilian Portuguese locale files.

## Key Changes
- **Memory Match game strings**: Added 13 localization keys including title, subtitle, instructions, difficulty levels (Easy, Medium, Hard), game over screen, and UI labels
- **Pet Runner game strings**: Added 11 localization keys including title, subtitle, instructions, game over screen with distance/coins/score tracking, and UI labels
- **Bilingual support**: All strings added to both `en.json` and `pt-BR.json` with appropriate translations

## Notable Details
- Both games include difficulty selection options for Memory Match
- Game over screens include score tracking and "Play Again" functionality
- Pet Runner includes distance and coin collection mechanics
- All strings follow the existing locale file structure and naming conventions
- Emoji icons included for visual appeal (🎮, 🎉, ⭐)

https://claude.ai/code/session_01CntWCjLmjENc52rVoW8o8C