### PR TITLE
Refactor game screens with useCallback and fix closure issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "expo": "~50.0.0",
     "expo-dev-client": "^6.0.20",
     "expo-haptics": "^15.0.8",
+    "expo-linear-gradient": "~12.3.0",
     "i18next": "^25.7.4",
     "pnpm": "^10.26.2",
     "react": "18.2.0",

--- a/src/context/ColorMixerContext.tsx
+++ b/src/context/ColorMixerContext.tsx
@@ -26,7 +26,7 @@ const ColorMixerContext = createContext<ColorMixerContextType | undefined>(undef
 
 export const ColorMixerProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user, isGuest } = useAuth();
-  const userId = user?.id || (isGuest ? 'guest' : 'guest');
+  const userId = user?.id || 'guest';
 
   const [progress, setProgress] = useState<ColorMixerProgressData>({ levels: {} });
   const progressRef = useRef<ColorMixerProgressData>({ levels: {} });

--- a/src/context/DressUpRelayContext.tsx
+++ b/src/context/DressUpRelayContext.tsx
@@ -13,7 +13,7 @@ const DressUpRelayContext = createContext<DressUpRelayContextType | undefined>(u
 
 export const DressUpRelayProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user, isGuest } = useAuth();
-  const userId = user?.id || (isGuest ? 'guest' : 'guest');
+  const userId = user?.id || 'guest';
 
   const [bestScore, setBestScore] = useState<number>(0);
   const bestScoreRef = useRef<number>(0);

--- a/src/context/SimonSaysContext.tsx
+++ b/src/context/SimonSaysContext.tsx
@@ -13,7 +13,7 @@ const SimonSaysContext = createContext<SimonSaysContextType | undefined>(undefin
 
 export const SimonSaysProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { user, isGuest } = useAuth();
-  const userId = user?.id || (isGuest ? 'guest' : 'guest');
+  const userId = user?.id || 'guest';
 
   const [bestScore, setBestScore] = useState<number>(0);
   const bestScoreRef = useRef<number>(0);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -367,6 +367,9 @@
     "dressYourPet": "Dress your pet!",
     "perfect": "Perfect! 🌟",
     "correct": "Correct!",
+    "target": "Target",
+    "yourOutfit": "Your Outfit",
+    "nextRound": "Next Round",
     "gameOver": {
       "title": "Game Over!",
       "totalScore": "Total Score",
@@ -393,6 +396,8 @@
     "backToLevels": "Back to Levels",
     "accuracy": "Accuracy",
     "levelsCompleted": "Levels Completed",
-    "totalStars": "Total Stars"
+    "totalStars": "Total Stars",
+    "dragHere": "Drag colors here",
+    "yourMix": "Your Mix"
   }
 }

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -368,6 +368,9 @@
     "dressYourPet": "Vista seu pet!",
     "perfect": "Perfeito! 🌟",
     "correct": "Correto!",
+    "target": "Alvo",
+    "yourOutfit": "Sua Roupa",
+    "nextRound": "Próxima Rodada",
     "gameOver": {
       "title": "Fim de Jogo!",
       "totalScore": "Pontuação Total",
@@ -394,6 +397,8 @@
     "backToLevels": "Voltar aos Níveis",
     "accuracy": "Precisão",
     "levelsCompleted": "Níveis Completados",
-    "totalStars": "Estrelas Totais"
+    "totalStars": "Estrelas Totais",
+    "dragHere": "Arraste as cores aqui",
+    "yourMix": "Sua Mistura"
   }
 }

--- a/src/screens/ColorMixerGameScreen.tsx
+++ b/src/screens/ColorMixerGameScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import {
   View,
   Text,
@@ -41,15 +41,17 @@ export const ColorMixerGameScreen: React.FC<Props> = ({ navigation, route }) => 
   const levelId = route.params.level;
   const level = LEVELS.find((l) => l.id === levelId);
 
-  if (!level) {
-    navigation.goBack();
-    return null;
-  }
-
   const [mixedColors, setMixedColors] = useState<RGB[]>([]);
   const [showResultModal, setShowResultModal] = useState(false);
   const [stars, setStars] = useState(0);
   const [accuracy, setAccuracy] = useState(0);
+
+  // Navigate back if level not found (avoid side effect during render)
+  useEffect(() => {
+    if (!level) {
+      navigation.goBack();
+    }
+  }, [level, navigation]);
 
   const currentMix = mixedColors.length > 0 ? mixColors(mixedColors) : { r: 255, g: 255, b: 255 };
 
@@ -92,6 +94,10 @@ export const ColorMixerGameScreen: React.FC<Props> = ({ navigation, route }) => 
     navigation.goBack();
   };
 
+  if (!level) {
+    return null;
+  }
+
   return (
     <GestureHandlerRootView style={styles.gestureRoot}>
       <LinearGradient colors={['#fef3c7', '#dbeafe']} style={styles.container}>
@@ -129,7 +135,7 @@ export const ColorMixerGameScreen: React.FC<Props> = ({ navigation, route }) => 
               <Text style={styles.sectionLabel}>{t('colorMixer.mixingBowl')}</Text>
               <View style={[styles.bowl, { backgroundColor: rgbToString(currentMix) }]}>
                 {mixedColors.length === 0 && (
-                  <Text style={styles.emptyBowlText}>Drag colors here</Text>
+                  <Text style={styles.emptyBowlText}>{t('colorMixer.dragHere')}</Text>
                 )}
               </View>
               <TouchableOpacity
@@ -201,7 +207,7 @@ export const ColorMixerGameScreen: React.FC<Props> = ({ navigation, route }) => 
                     />
                   </View>
                   <View style={styles.comparisonItem}>
-                    <Text style={styles.comparisonLabel}>Your Mix</Text>
+                    <Text style={styles.comparisonLabel}>{t('colorMixer.yourMix')}</Text>
                     <View
                       style={[
                         styles.comparisonSwatch,

--- a/src/screens/ColorMixerHomeScreen.tsx
+++ b/src/screens/ColorMixerHomeScreen.tsx
@@ -5,12 +5,11 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { useColorMixer } from '../context/ColorMixerContext';
 import { ScreenNavigationProp } from '../types/navigation';
 import { EmojiIcon } from '../components/EmojiIcon';
+import { TOTAL_LEVELS } from '../data/colorMixerLevels';
 
 type Props = {
   navigation: ScreenNavigationProp<'ColorMixerHome'>;
 };
-
-const TOTAL_LEVELS = 20;
 
 export const ColorMixerHomeScreen: React.FC<Props> = ({ navigation }) => {
   const { t } = useTranslation();

--- a/src/screens/DressUpRelayGameScreen.tsx
+++ b/src/screens/DressUpRelayGameScreen.tsx
@@ -159,6 +159,7 @@ export const DressUpRelayGameScreen: React.FC<Props> = ({ navigation }) => {
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const countdownTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const previewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handleSubmitRef = useRef<() => void>(() => {});
 
   const countdownAnim = useRef(new Animated.Value(1)).current;
 
@@ -221,8 +222,8 @@ export const DressUpRelayGameScreen: React.FC<Props> = ({ navigation }) => {
         setTimeRemaining((prev) => {
           if (prev <= 100) {
             clearInterval(timerRef.current!);
-            // Time's up - check outfit
-            handleSubmit();
+            // Time's up - use ref to avoid stale closure
+            handleSubmitRef.current();
             return 0;
           }
           // Haptic at 5 seconds
@@ -270,6 +271,9 @@ export const DressUpRelayGameScreen: React.FC<Props> = ({ navigation }) => {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
     }
   }, [playerOutfit, targetOutfit, timeRemaining]);
+
+  // Keep ref in sync so the timer interval always calls the latest handleSubmit
+  handleSubmitRef.current = handleSubmit;
 
   const handleNextRound = useCallback(() => {
     if (round >= TOTAL_ROUNDS) {
@@ -447,7 +451,7 @@ export const DressUpRelayGameScreen: React.FC<Props> = ({ navigation }) => {
               onPress={handleSubmit}
               activeOpacity={0.85}
             >
-              <Text style={styles.submitButtonText}>{t('dressUpRelay.correct')}</Text>
+              <Text style={styles.submitButtonText}>{t('colorMixer.check')}</Text>
             </TouchableOpacity>
           )}
         </>
@@ -462,11 +466,11 @@ export const DressUpRelayGameScreen: React.FC<Props> = ({ navigation }) => {
 
           <View style={styles.resultComparison}>
             <View style={styles.resultColumn}>
-              <Text style={styles.resultLabel}>Target</Text>
+              <Text style={styles.resultLabel}>{t('dressUpRelay.target')}</Text>
               <PetRenderer pet={targetPet} size={140} animationState="idle" />
             </View>
             <View style={styles.resultColumn}>
-              <Text style={styles.resultLabel}>Your Outfit</Text>
+              <Text style={styles.resultLabel}>{t('dressUpRelay.yourOutfit')}</Text>
               <PetRenderer pet={playerPet} size={140} animationState="idle" />
             </View>
           </View>
@@ -492,7 +496,7 @@ export const DressUpRelayGameScreen: React.FC<Props> = ({ navigation }) => {
 
           <TouchableOpacity style={styles.nextButton} onPress={handleNextRound} activeOpacity={0.85}>
             <Text style={styles.nextButtonText}>
-              {round >= TOTAL_ROUNDS ? t('dressUpRelay.gameOver.title') : 'Next Round'}
+              {round >= TOTAL_ROUNDS ? t('dressUpRelay.gameOver.title') : t('dressUpRelay.nextRound')}
             </Text>
           </TouchableOpacity>
         </View>

--- a/src/screens/DressUpRelayHomeScreen.tsx
+++ b/src/screens/DressUpRelayHomeScreen.tsx
@@ -33,7 +33,7 @@ export const DressUpRelayHomeScreen: React.FC<Props> = ({ navigation }) => {
         accessibilityRole="button"
         accessibilityLabel={t('common.back')}
       >
-        <Text style={styles.backText}>{t('common.back')}</Text>
+        <Text style={styles.backText}>← {t('common.back')}</Text>
       </TouchableOpacity>
 
       <View style={styles.content}>

--- a/src/screens/DressUpRelayNavigator.tsx
+++ b/src/screens/DressUpRelayNavigator.tsx
@@ -9,6 +9,7 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
 export const DressUpRelayNavigator: React.FC = () => {
   return (
     <Stack.Navigator
+      initialRouteName="DressUpRelayHome"
       screenOptions={{
         headerShown: false,
         animation: 'slide_from_right',

--- a/src/screens/SimonSaysGameScreen.tsx
+++ b/src/screens/SimonSaysGameScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import {
   View,
   Text,
@@ -11,7 +11,6 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useSimonSays } from '../context/SimonSaysContext';
 import { ScreenNavigationProp } from '../types/navigation';
-import { Audio } from 'expo-av';
 import * as Haptics from 'expo-haptics';
 
 type Props = {
@@ -21,10 +20,10 @@ type Props = {
 type ColorId = 0 | 1 | 2 | 3;
 
 const COLORS = [
-  { id: 0, name: 'red', color: '#e74c3c', lightColor: '#ff6b6b', frequency: 440 },
-  { id: 1, name: 'blue', color: '#3498db', lightColor: '#74b9ff', frequency: 494 },
-  { id: 2, name: 'green', color: '#27ae60', lightColor: '#55efc4', frequency: 523 },
-  { id: 3, name: 'yellow', color: '#f1c40f', lightColor: '#ffeaa7', frequency: 587 },
+  { id: 0, name: 'red', color: '#e74c3c', lightColor: '#ff6b6b' },
+  { id: 1, name: 'blue', color: '#3498db', lightColor: '#74b9ff' },
+  { id: 2, name: 'green', color: '#27ae60', lightColor: '#55efc4' },
+  { id: 3, name: 'yellow', color: '#f1c40f', lightColor: '#ffeaa7' },
 ];
 
 type GamePhase = 'ready' | 'showing' | 'playing' | 'correct' | 'wrong' | 'gameOver';
@@ -40,53 +39,21 @@ export const SimonSaysGameScreen: React.FC<Props> = ({ navigation }) => {
   const [phase, setPhase] = useState<GamePhase>('ready');
   const [activeButton, setActiveButton] = useState<ColorId | null>(null);
   const [showGameOver, setShowGameOver] = useState(false);
+  const [isNewRecord, setIsNewRecord] = useState(false);
+
+  // Use refs to avoid stale closures in setTimeout callbacks
+  const sequenceRef = useRef<ColorId[]>([]);
+  const currentRoundRef = useRef<number>(0);
+  const bestScoreRef = useRef<number>(bestScore);
 
   const scaleAnims = useRef(COLORS.map(() => new Animated.Value(1))).current;
 
+  // Keep bestScoreRef in sync
   useEffect(() => {
-    startNewRound();
-  }, []);
+    bestScoreRef.current = bestScore;
+  }, [bestScore]);
 
-  const startNewRound = () => {
-    const newColor = Math.floor(Math.random() * 4) as ColorId;
-    const newSequence = [...sequence, newColor];
-    setSequence(newSequence);
-    setPlayerSequence([]);
-    setCurrentRound(currentRound + 1);
-    setPhase('showing');
-
-    setTimeout(() => {
-      playSequence(newSequence);
-    }, 1000);
-  };
-
-  const playSequence = async (seq: ColorId[]) => {
-    const delay = currentRound >= 10 ? 600 : 1000;
-
-    for (let i = 0; i < seq.length; i++) {
-      await new Promise((resolve) => setTimeout(resolve, delay));
-      await activateButton(seq[i], 300);
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    setPhase('playing');
-  };
-
-  const activateButton = async (colorId: ColorId, duration: number) => {
-    setActiveButton(colorId);
-    playTone(COLORS[colorId].frequency);
-    animateButton(colorId);
-    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        setActiveButton(null);
-        resolve(true);
-      }, duration);
-    });
-  };
-
-  const animateButton = (colorId: ColorId) => {
+  const animateButton = useCallback((colorId: ColorId) => {
     Animated.sequence([
       Animated.spring(scaleAnims[colorId], {
         toValue: 1.05,
@@ -99,30 +66,65 @@ export const SimonSaysGameScreen: React.FC<Props> = ({ navigation }) => {
         speed: 50,
       }),
     ]).start();
-  };
+  }, [scaleAnims]);
 
-  const playTone = async (frequency: number) => {
-    // Simple beep sound using expo-av
-    // In a real implementation, you would load actual sound files
-    try {
-      const { sound } = await Audio.Sound.createAsync(
-        { uri: `data:audio/wav;base64,${generateToneBase64(frequency)}` },
-        { shouldPlay: true }
-      );
+  const activateButton = useCallback(async (colorId: ColorId, duration: number) => {
+    setActiveButton(colorId);
+    animateButton(colorId);
+    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+
+    return new Promise((resolve) => {
       setTimeout(() => {
-        sound.unloadAsync();
-      }, 300);
-    } catch (error) {
-      console.log('Audio error:', error);
+        setActiveButton(null);
+        resolve(true);
+      }, duration);
+    });
+  }, [animateButton]);
+
+  const playSequence = useCallback(async (seq: ColorId[], round: number) => {
+    const delay = round >= 10 ? 600 : 1000;
+
+    for (let i = 0; i < seq.length; i++) {
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      await activateButton(seq[i], 300);
     }
-  };
 
-  const generateToneBase64 = (frequency: number): string => {
-    // Placeholder - in production, use actual audio files
-    return '';
-  };
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    setPhase('playing');
+  }, [activateButton]);
 
-  const handleButtonPress = async (colorId: ColorId) => {
+  const startNewRound = useCallback(() => {
+    const newColor = Math.floor(Math.random() * 4) as ColorId;
+    const newSequence = [...sequenceRef.current, newColor];
+    const newRound = currentRoundRef.current + 1;
+
+    sequenceRef.current = newSequence;
+    currentRoundRef.current = newRound;
+
+    setSequence(newSequence);
+    setPlayerSequence([]);
+    setCurrentRound(newRound);
+    setPhase('showing');
+
+    setTimeout(() => {
+      playSequence(newSequence, newRound);
+    }, 1000);
+  }, [playSequence]);
+
+  const endGame = useCallback(() => {
+    // currentRound is the round where the player failed, so completed = currentRound - 1
+    const roundsCompleted = currentRoundRef.current - 1;
+    const finalScore = Math.max(0, roundsCompleted);
+    const newRecord = finalScore > bestScoreRef.current;
+
+    setScore(finalScore);
+    setIsNewRecord(newRecord);
+    updateBestScore(finalScore);
+    setPhase('gameOver');
+    setShowGameOver(true);
+  }, [updateBestScore]);
+
+  const handleButtonPress = useCallback(async (colorId: ColorId) => {
     if (phase !== 'playing') return;
 
     const newPlayerSequence = [...playerSequence, colorId];
@@ -131,7 +133,7 @@ export const SimonSaysGameScreen: React.FC<Props> = ({ navigation }) => {
     await activateButton(colorId, 200);
 
     // Check if the input is correct
-    if (colorId !== sequence[newPlayerSequence.length - 1]) {
+    if (colorId !== sequenceRef.current[newPlayerSequence.length - 1]) {
       // Wrong!
       setPhase('wrong');
       await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
@@ -142,10 +144,10 @@ export const SimonSaysGameScreen: React.FC<Props> = ({ navigation }) => {
     }
 
     // Check if sequence is complete
-    if (newPlayerSequence.length === sequence.length) {
+    if (newPlayerSequence.length === sequenceRef.current.length) {
       // Correct! Move to next round
       setPhase('correct');
-      const newScore = currentRound;
+      const newScore = currentRoundRef.current;
       setScore(newScore);
       await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
 
@@ -153,27 +155,27 @@ export const SimonSaysGameScreen: React.FC<Props> = ({ navigation }) => {
         startNewRound();
       }, 1500);
     }
-  };
+  }, [phase, playerSequence, activateButton, endGame, startNewRound]);
 
-  const endGame = () => {
-    const finalScore = currentRound;
-    setScore(finalScore);
-    updateBestScore(finalScore);
-    setPhase('gameOver');
-    setShowGameOver(true);
-  };
+  useEffect(() => {
+    startNewRound();
+  }, []);
 
-  const handlePlayAgain = () => {
+  const handlePlayAgain = useCallback(() => {
+    sequenceRef.current = [];
+    currentRoundRef.current = 0;
+
     setSequence([]);
     setPlayerSequence([]);
     setCurrentRound(0);
     setScore(0);
+    setIsNewRecord(false);
     setPhase('ready');
     setShowGameOver(false);
     setTimeout(() => {
       startNewRound();
     }, 500);
-  };
+  }, [startNewRound]);
 
   const handleBack = () => {
     if (navigation.canGoBack()) {
@@ -262,10 +264,10 @@ export const SimonSaysGameScreen: React.FC<Props> = ({ navigation }) => {
               <Text style={styles.scoreLabel}>
                 {t('simonSays.gameOver.roundsCompleted')}
               </Text>
-              <Text style={styles.scoreValue}>{currentRound}</Text>
+              <Text style={styles.scoreValue}>{score}</Text>
             </View>
 
-            {score > bestScore && (
+            {isNewRecord && (
               <Text style={styles.newRecord}>🎉 {t('simonSays.gameOver.newRecord')}</Text>
             )}
 


### PR DESCRIPTION
## Summary
This PR refactors multiple game screens to improve performance and fix stale closure bugs by introducing `useCallback` hooks, using refs for mutable state in closures, and adding proper i18n translations for UI text.

## Key Changes

### SimonSaysGameScreen
- Added `useCallback` hooks to memoize `animateButton`, `activateButton`, `playSequence`, `startNewRound`, `endGame`, and `handleButtonPress` to prevent unnecessary re-renders and fix stale closure issues
- Removed unused `expo-av` Audio import and frequency properties from COLORS array (audio functionality was placeholder code)
- Introduced refs (`sequenceRef`, `currentRoundRef`, `bestScoreRef`) to maintain correct state in setTimeout callbacks and avoid stale closures
- Fixed game over logic to properly calculate completed rounds and track new records with `isNewRecord` state
- Fixed score display in game over modal to show `score` instead of `currentRound`

### ColorMixerGameScreen
- Moved side effect (navigation.goBack) from render into a `useEffect` hook to avoid calling navigation during render
- Added i18n translations for hardcoded strings: "Drag colors here" and "Your Mix"

### DressUpRelayGameScreen
- Added `handleSubmitRef` to maintain reference to latest `handleSubmit` function in timer interval, preventing stale closure bugs
- Replaced hardcoded strings with i18n translations: "Target", "Your Outfit", "Next Round", and "Check"
- Fixed submit button text to use correct translation key

### Context Files (SimonSaysContext, ColorMixerContext, DressUpRelayContext)
- Simplified userId fallback logic from `user?.id || (isGuest ? 'guest' : 'guest')` to `user?.id || 'guest'`

### Localization
- Added missing translation keys to both English and Portuguese-BR locale files for game UI text

### Other
- Added `expo-linear-gradient` to package.json dependencies
- Set `initialRouteName="DressUpRelayHome"` in DressUpRelayNavigator for explicit navigation setup
- Extracted `TOTAL_LEVELS` constant to a separate data file for reusability

## Notable Implementation Details
- Used refs strategically to avoid stale closures in timer/setTimeout callbacks while keeping state updates clean
- Maintained separation of concerns by keeping UI state (setters) separate from closure-safe refs
- All memoized callbacks properly declare their dependencies in dependency arrays

https://claude.ai/code/session_01BXAL7REb538CWacPgvGfrx