### PR TITLE
Fix missing comma in en.json locale file

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -252,6 +252,7 @@
     "colorMixer": {
       "name": "Color Mixer Lab",
       "description": "Mix the perfect color!"
+    },
     "feedThePet": {
       "name": "Feed the Pet",
       "description": "Catch falling food!"


### PR DESCRIPTION
## Summary
Fixed a JSON syntax error in the English locale file by adding a missing comma after the "colorMixer" object definition.

## Key Changes
- Added missing comma after the `colorMixer` object in `src/locales/en.json`

## Details
The JSON structure was missing a comma between the `colorMixer` and `feedThePet` object properties, which would have caused a JSON parsing error. This fix ensures the locale file is valid JSON and can be properly loaded by the application.

https://claude.ai/code/session_01LGAPUpbwyWKLcQBfbZdxrX