### PR TITLE
Fix JSON syntax error in Portuguese locale file

### DIFF
--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -253,6 +253,7 @@
     "colorMixer": {
       "name": "Laboratório de Cores",
       "description": "Misture a cor perfeita!"
+    },
     "feedThePet": {
       "name": "Alimentar o Pet",
       "description": "Pegue a comida que cai!"


### PR DESCRIPTION
## Summary
Fixed a missing comma in the Portuguese (Brazil) locale file that was causing invalid JSON syntax.

## Key Changes
- Added missing comma after the `colorMixer` object in `src/locales/pt-BR.json`
- This ensures proper JSON formatting and prevents parsing errors

## Details
The `colorMixer` object definition was missing a trailing comma before the `feedThePet` object, which would cause JSON parsing to fail. This fix restores valid JSON structure in the locale file.

https://claude.ai/code/session_01TGzso7FR2rXCAwNUU1GcYM