### PR TITLE
Simplify auth context usage and remove unused import

### DIFF
--- a/src/context/CatchTheBallContext.tsx
+++ b/src/context/CatchTheBallContext.tsx
@@ -12,8 +12,8 @@ interface CatchTheBallContextType {
 const CatchTheBallContext = createContext<CatchTheBallContextType | undefined>(undefined);
 
 export const CatchTheBallProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { user, isGuest } = useAuth();
-  const userId = user?.id || (isGuest ? 'guest' : 'guest');
+  const { user } = useAuth();
+  const userId = user?.id || 'guest';
   const storageKey = `${STORAGE_KEY_BASE}:${userId}`;
 
   const [bestScore, setBestScore] = useState(0);

--- a/src/context/SlidingPuzzleContext.tsx
+++ b/src/context/SlidingPuzzleContext.tsx
@@ -17,8 +17,8 @@ interface SlidingPuzzleContextType {
 const SlidingPuzzleContext = createContext<SlidingPuzzleContextType | undefined>(undefined);
 
 export const SlidingPuzzleProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { user, isGuest } = useAuth();
-  const userId = user?.id || (isGuest ? 'guest' : 'guest');
+  const { user } = useAuth();
+  const userId = user?.id || 'guest';
   const storageKey = `${STORAGE_KEY_BASE}:${userId}`;
 
   const [bestMoves, setBestMoves] = useState<BestMoves>({ easy: null, hard: null });

--- a/src/screens/SlidingPuzzleGameScreen.tsx
+++ b/src/screens/SlidingPuzzleGameScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import {
   View,
   Text,


### PR DESCRIPTION
## Summary
This PR simplifies the authentication context usage across game providers and removes an unused import from the Sliding Puzzle game screen.

## Key Changes
- **Removed unused `isGuest` destructuring** from `useAuth()` hook in both `CatchTheBallContext` and `SlidingPuzzleContext`
- **Simplified userId fallback logic** from the redundant ternary `(isGuest ? 'guest' : 'guest')` to a simple `'guest'` string literal in both contexts
- **Removed unused `useEffect` import** from `SlidingPuzzleGameScreen.tsx` that was not being utilized in the component

## Implementation Details
The changes maintain the same functionality while improving code clarity. The `isGuest` variable was not being used meaningfully (both branches of the ternary returned the same value), so removing it eliminates unnecessary complexity. The userId fallback now directly uses the 'guest' string when no authenticated user is present.

https://claude.ai/code/session_014PyCcASk9a6gKQxiUxcMv7