### PR TITLE
Don't persist guest mode state to AsyncStorage

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -61,13 +61,11 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
           logger.info('Web platform detected - using fallback auth mode (no OAuth)');
         }
 
-        // Restore auth state from AsyncStorage
+        // Restore auth state from AsyncStorage (guest mode is not persisted)
         const savedAuthState = await AsyncStorage.getItem(AUTH_STORAGE_KEY);
         if (savedAuthState) {
-          const { user: savedUser, isGuest: savedIsGuest } = JSON.parse(savedAuthState);
-          if (savedIsGuest) {
-            setIsGuest(true);
-          } else if (savedUser) {
+          const { user: savedUser } = JSON.parse(savedAuthState);
+          if (savedUser) {
             setUser(savedUser);
           }
         }
@@ -216,11 +214,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       setUser(null);
       setIsGuest(true);
 
-      // Save guest mode state
-      await AsyncStorage.setItem(
-        AUTH_STORAGE_KEY,
-        JSON.stringify({ user: null, isGuest: true })
-      );
+      // Guest mode is intentionally not persisted — guests see the login screen on next launch
     } catch (err) {
       logger.error('Guest mode error:', err);
       setError('Failed to enable guest mode');


### PR DESCRIPTION
## Summary
Modified the authentication context to prevent guest mode from being persisted to device storage. This ensures users see the login screen on app launch rather than automatically resuming a guest session.

## Key Changes
- Removed `isGuest` flag from AsyncStorage persistence logic during auth state restoration
- Removed the code that saved guest mode state (`isGuest: true`) when entering guest mode
- Added clarifying comments explaining that guest mode is intentionally not persisted

## Implementation Details
- When restoring auth state from AsyncStorage, the code now only checks for a saved user object and ignores any previously stored `isGuest` flag
- The `enterGuestMode()` function no longer writes guest state to AsyncStorage, while still setting the in-memory `isGuest` state
- This ensures that guest sessions are ephemeral and don't survive app restarts, providing a cleaner UX where users must explicitly choose to log in or enter guest mode on each launch

https://claude.ai/code/session_01CR47AzsCpWueMu33RLPtU8