### PR TITLE
Fix import paths in app directory to use relative imports

### DIFF
--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -3,14 +3,14 @@ import { ActivityIndicator, View, StyleSheet } from 'react-native';
 import { Stack, useRouter, useSegments, usePathname } from 'expo-router';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
-import './src/i18n';
-import { registerAllGames } from './src/gameRegistrations';
-import { ErrorBoundary } from './src/components/ErrorBoundary';
-import { LanguageProvider } from './src/context/LanguageContext';
-import { AuthProvider, useAuth } from './src/context/AuthContext';
-import { ToastProvider } from './src/context/ToastContext';
-import { AdProvider, useAd } from './src/context/AdContext';
-import AdService from './src/services/AdService';
+import '../src/i18n';
+import { registerAllGames } from '../src/gameRegistrations';
+import { ErrorBoundary } from '../src/components/ErrorBoundary';
+import { LanguageProvider } from '../src/context/LanguageContext';
+import { AuthProvider, useAuth } from '../src/context/AuthContext';
+import { ToastProvider } from '../src/context/ToastContext';
+import { AdProvider, useAd } from '../src/context/AdContext';
+import AdService from '../src/services/AdService';
 
 registerAllGames();
 

--- a/app/app/index.tsx
+++ b/app/app/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GameSelectionScreen } from './src/screens/GameSelectionScreen';
+import { GameSelectionScreen } from '../src/screens/GameSelectionScreen';
 
 export default function GameSelectionRoute() {
   return <GameSelectionScreen />;

--- a/app/app/login.tsx
+++ b/app/app/login.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LoginScreen } from './src/screens/LoginScreen';
+import { LoginScreen } from '../src/screens/LoginScreen';
 
 export default function LoginRoute() {
   return <LoginScreen />;


### PR DESCRIPTION
## Summary
Updated import paths in the app directory to use relative imports (`../src/...`) instead of absolute imports (`./src/...`). This ensures consistent module resolution across the application structure.

## Key Changes
- Updated `app/_layout.tsx` to use relative imports for all dependencies (i18n, gameRegistrations, components, contexts, and services)
- Updated `app/index.tsx` to use relative import for GameSelectionScreen
- Updated `app/login.tsx` to use relative import for LoginScreen

## Details
The import paths were adjusted to correctly reference the `src` directory from the `app` directory level. This change maintains consistency with the project's directory structure where `src` is a sibling directory to `app`, requiring relative path traversal (`../src/...`) rather than direct child references (`./src/...`).

https://claude.ai/code/session_01LHM9qyNVBALLBrk7JKQtpC