### PR TITLE
fix: pin pnpm version in Vercel install command to resolve ERR_INVALI…

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -39,7 +39,6 @@
     "expo-router": "~3.4.10",
     "expo-status-bar": "~1.11.1",
     "i18next": "^25.7.4",
-    "pnpm": "^10.26.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-i18next": "^16.5.3",

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -2,7 +2,7 @@
   "buildCommand": "EXPO_PUBLIC_BUILD_PLATFORM=web npx expo export --platform web",
   "outputDirectory": "dist",
   "framework": null,
-  "installCommand": "pnpm install --no-frozen-lockfile",
+  "installCommand": "npm install -g pnpm@10.30.2 && pnpm install --no-frozen-lockfile",
   "rewrites": [
     { "source": "/(.*)", "destination": "/index.html" }
   ]


### PR DESCRIPTION
…D_THIS

Vercel was using its bundled (older) pnpm binary which has a bug causing ERR_INVALID_THIS / URLSearchParams errors when fetching packages on Node 20. Fix by explicitly installing pnpm@10.30.2 via npm before running pnpm install. Also removes pnpm from dependencies — the packageManager field is the correct way to declare the package manager version.