### PR TITLE
Add game selection and game-specific localization strings

### DIFF
--- a/app/src/locales/en.json
+++ b/app/src/locales/en.json
@@ -412,5 +412,564 @@
       "name": "Photo Studio",
       "description": "Take cute photos of your pet!"
     }
+  },
+  "balloonFloat": {
+    "home": {
+      "title": "Balloon Float",
+      "subtitle": "Float your balloon to the top!",
+      "play": "Play",
+      "instructions": "Tap to make your balloon rise. Avoid obstacles!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "score": "Score",
+      "gameOver": "Game Over",
+      "playAgain": "Play Again"
+    }
+  },
+  "bubblePop": {
+    "home": {
+      "title": "Bubble Pop",
+      "subtitle": "Pop all the colorful bubbles!",
+      "play": "Play",
+      "instructions": "Tap bubbles to pop them all!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "score": "Score",
+      "combo": "Combo",
+      "finalScore": "Final Score",
+      "gameOver": "Game Over",
+      "playAgain": "Play Again"
+    }
+  },
+  "catchTheBall": {
+    "home": {
+      "title": "Catch the Ball",
+      "subtitle": "Catch falling balls in your basket!",
+      "play": "Play",
+      "instructions": "Move your basket to catch falling balls!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "score": "Score",
+      "caught": "Caught",
+      "missed": "Missed",
+      "lane": "Lane",
+      "finalScore": "Final Score",
+      "gameOver": "Game Over",
+      "newBest": "New Best!",
+      "coinsEarned": "Coins Earned",
+      "ready": "Ready!",
+      "tapToStart": "Tap to Start",
+      "playAgain": "Play Again",
+      "back": "Back"
+    }
+  },
+  "colorMixer": {
+    "title": "Color Mixer",
+    "subtitle": "Mix colors to match the target!",
+    "play": "Play",
+    "instructions": "Drag color swatches into the bowl to match the target color!",
+    "levelsCompleted": "Levels Completed",
+    "totalStars": "Total Stars",
+    "level": "Level",
+    "levelComplete": "Level Complete!",
+    "accuracy": "Accuracy",
+    "backToLevels": "Back to Levels",
+    "nextLevel": "Next Level",
+    "tryAgain": "Try Again",
+    "check": "Check",
+    "reset": "Reset",
+    "target": "Target",
+    "yourMix": "Your Mix",
+    "dragHere": "Drag here",
+    "mixingBowl": "Mixing Bowl"
+  },
+  "colorTap": {
+    "title": "Color Tap",
+    "subtitle": "Tap the right colors fast!",
+    "play": "Play",
+    "instructions": "Tap the colored buttons in the correct order!",
+    "bestScore": "Best Score",
+    "gameOver": {
+      "title": "Game Over",
+      "playAgain": "Play Again"
+    }
+  },
+  "connectDots": {
+    "home": {
+      "title": "Connect Dots",
+      "subtitle": "Connect the dots to reveal the picture!",
+      "play": "Play",
+      "instructions": "Connect all dots in order to complete the image!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "complete": "Complete!",
+      "revealed": "Revealed",
+      "tapNext": "Tap next dot",
+      "playAgain": "Play Again"
+    }
+  },
+  "dressUpRelay": {
+    "title": "Dress Up Relay",
+    "subtitle": "Dress up your pet in style!",
+    "play": "Play",
+    "instructions": "Memorize the outfit and recreate it on your pet!",
+    "bestScore": "Best Score",
+    "round": "Round",
+    "timeLeft": "Time Left",
+    "memorize": "Memorize the outfit!",
+    "dressYourPet": "Dress your pet!",
+    "target": "Target",
+    "yourOutfit": "Your Outfit",
+    "correct": "Correct!",
+    "perfect": "Perfect!",
+    "nextRound": "Next Round",
+    "gameOver": {
+      "title": "Game Over",
+      "playAgain": "Play Again",
+      "roundsCompleted": "Rounds Completed",
+      "totalScore": "Total Score"
+    }
+  },
+  "feedThePet": {
+    "home": {
+      "title": "Feed the Pet",
+      "subtitle": "Catch falling food for your pet!",
+      "play": "Play",
+      "instructions": "Move the bowl to catch falling food for your hungry pet!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "score": "Score",
+      "combo": "Combo",
+      "finalScore": "Final Score",
+      "gameOver": "Game Over",
+      "newBest": "New Best!",
+      "coinsEarned": "Coins Earned",
+      "playAgain": "Play Again",
+      "back": "Back"
+    }
+  },
+  "gardenGrow": {
+    "home": {
+      "title": "Garden Grow",
+      "subtitle": "Grow a beautiful garden!",
+      "play": "Play",
+      "instructions": "Water and tend your plants to grow a stunning garden!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "title": "Garden Grow",
+      "complete": "Garden Complete!",
+      "harvested": "Harvested",
+      "playAgain": "Play Again"
+    }
+  },
+  "jigsawPets": {
+    "home": {
+      "title": "Jigsaw Pets",
+      "subtitle": "Complete the pet puzzle!",
+      "play": "Play",
+      "instructions": "Drag puzzle pieces to complete the adorable pet image!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "title": "Jigsaw Pets",
+      "complete": "Puzzle Complete!",
+      "moves": "Moves",
+      "pieces": "Pieces",
+      "placing": "Placing...",
+      "tapCell": "Tap a cell",
+      "playAgain": "Play Again"
+    }
+  },
+  "lightningTap": {
+    "home": {
+      "title": "Lightning Tap",
+      "subtitle": "Tap as fast as lightning!",
+      "play": "Play",
+      "instructions": "Tap the glowing targets as fast as you can!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "score": "Score",
+      "misses": "Misses",
+      "gameOver": "Game Over",
+      "playAgain": "Play Again"
+    }
+  },
+  "memoryMatch": {
+    "title": "Memory Match",
+    "subtitle": "Find all matching pairs!",
+    "play": "Play",
+    "instructions": "Flip cards to find matching pairs. Remember the locations!",
+    "bestScore": "Best Score",
+    "moves": "Moves",
+    "matched": "Matched!",
+    "cardFaceDown": "Card face down",
+    "gameOver": {
+      "title": "You Win!",
+      "moves": "Moves",
+      "time": "Time",
+      "score": "Score",
+      "playAgain": "Play Again"
+    }
+  },
+  "mirrorMatch": {
+    "home": {
+      "title": "Mirror Match",
+      "subtitle": "Mirror the patterns to win!",
+      "play": "Play",
+      "instructions": "Copy the pattern shown on the left side to the right!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "title": "Mirror Match",
+      "pattern": "Pattern",
+      "mirror": "Mirror",
+      "color": "Color",
+      "check": "Check",
+      "perfect": "Perfect!",
+      "score": "Score"
+    }
+  },
+  "muito": {
+    "title": "Muito",
+    "subtitle": "Match numbers to score big!",
+    "play": "Play",
+    "instructions": "Match the number on the screen with the right answer!",
+    "bestScore": "Best Score",
+    "score": "Score",
+    "answerLabel": "Answer",
+    "correct": "Correct!",
+    "wrong": "Wrong!",
+    "multiplayer": {
+      "title": "Multiplayer",
+      "play": "Multiplayer",
+      "host": "Host",
+      "join": "Join",
+      "createRoom": "Create Room",
+      "joinRoom": "Join Room",
+      "hostDescription": "Create a room and invite friends",
+      "joinDescription": "Join a friend's room",
+      "roomCode": "Room Code",
+      "codePlaceholder": "Enter room code...",
+      "lobby": "Lobby",
+      "players": "Players",
+      "waitingForOpponent": "Waiting for opponent...",
+      "waitingForHost": "Waiting for host...",
+      "waitingForRound": "Waiting for next round...",
+      "start": "Start Game",
+      "connecting": "Connecting...",
+      "opponent": "Opponent",
+      "you": "You",
+      "youWonRound": "You won this round!",
+      "opponentWonRound": "Opponent won this round!",
+      "tieRound": "It's a tie!",
+      "resultWin": "You Win!",
+      "resultLose": "You Lose!",
+      "resultTie": "It's a Tie!",
+      "playAgain": "Play Again",
+      "backToMenu": "Back to Menu"
+    }
+  },
+  "musicMaker": {
+    "home": {
+      "title": "Music Maker",
+      "subtitle": "Create fun music with your pet!",
+      "play": "Play",
+      "instructions": "Tap the instruments to create your own music!",
+      "bestScore": "Songs Made"
+    },
+    "game": {
+      "title": "Music Maker",
+      "save": "Save",
+      "clear": "Clear"
+    }
+  },
+  "paintSplash": {
+    "home": {
+      "title": "Paint Splash",
+      "subtitle": "Create colorful splashes of paint!",
+      "play": "Play",
+      "instructions": "Tap the canvas to create colorful paint splashes!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "title": "Paint Splash",
+      "score": "Score",
+      "selectColor": "Select Color",
+      "complete": "Complete!",
+      "playAgain": "Play Again"
+    }
+  },
+  "pathFinder": {
+    "home": {
+      "title": "Path Finder",
+      "subtitle": "Find the path to the goal!",
+      "play": "Play",
+      "instructions": "Draw a path from start to finish avoiding obstacles!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "title": "Path Finder",
+      "score": "Score",
+      "steps": "Steps",
+      "hint": "Hint",
+      "reset": "Reset",
+      "pathFound": "Path Found!",
+      "playAgain": "Play Again"
+    }
+  },
+  "petChef": {
+    "home": {
+      "title": "Pet Chef",
+      "subtitle": "Cook delicious meals for pets!",
+      "play": "Play",
+      "instructions": "Follow the recipe to cook the perfect meal!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "recipe": "Recipe",
+      "ingredients": "Ingredients",
+      "serve": "Serve!",
+      "next": "Next",
+      "complete": "Meal Complete!",
+      "playAgain": "Play Again"
+    }
+  },
+  "petDanceParty": {
+    "home": {
+      "title": "Pet Dance Party",
+      "subtitle": "Dance along with your pet!",
+      "play": "Play",
+      "instructions": "Follow the dance moves shown on screen!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "finalScore": "Final Score",
+      "gameOver": "Game Over",
+      "playAgain": "Play Again"
+    }
+  },
+  "petExplorer": {
+    "home": {
+      "title": "Pet Explorer",
+      "subtitle": "Explore the world with your pet!",
+      "play": "Play",
+      "instructions": "Guide your pet through exciting locations to discover treasures!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "score": "Score",
+      "exploring": "Exploring...",
+      "complete": "Exploration Complete!",
+      "finish": "Finish",
+      "playAgain": "Play Again"
+    }
+  },
+  "petRunner": {
+    "title": "Pet Runner",
+    "subtitle": "Run, jump, and dodge obstacles!",
+    "play": "Play",
+    "instructions": "Tap to jump over obstacles and run as far as you can!",
+    "bestScore": "Best Score",
+    "tapToStart": "Tap to Start",
+    "gameOver": {
+      "title": "Game Over",
+      "score": "Score",
+      "distance": "Distance",
+      "coins": "Coins",
+      "newBest": "New Best!",
+      "playAgain": "Play Again"
+    }
+  },
+  "petTaxi": {
+    "home": {
+      "title": "Pet Taxi",
+      "subtitle": "Drive your pet taxi around town!",
+      "play": "Play",
+      "instructions": "Pick up passengers and deliver them to their destinations!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "deliver": "Deliver",
+      "delivered": "Delivered!",
+      "gameOver": "Game Over",
+      "playAgain": "Play Again"
+    }
+  },
+  "photoStudio": {
+    "home": {
+      "title": "Photo Studio",
+      "subtitle": "Take cute photos of your pet!",
+      "play": "Play",
+      "instructions": "Choose poses, props, and backgrounds for the perfect pet photo!",
+      "bestScore": "Photos Taken"
+    },
+    "game": {
+      "title": "Photo Studio",
+      "background": "Background",
+      "pose": "Pose",
+      "props": "Props",
+      "stickers": "Stickers",
+      "gallery": "Gallery",
+      "takePhoto": "Take Photo!"
+    }
+  },
+  "shapeSorter": {
+    "home": {
+      "title": "Shape Sorter",
+      "subtitle": "Sort shapes into the right slots!",
+      "play": "Play",
+      "instructions": "Drag shapes to their matching slots as fast as you can!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "score": "Score",
+      "round": "Round",
+      "shapes": "Shapes",
+      "holes": "Holes",
+      "selected": "Selected",
+      "tapHole": "Tap a hole",
+      "complete": "Round Complete!",
+      "playAgain": "Play Again"
+    }
+  },
+  "simonSays": {
+    "title": "Simon Says",
+    "subtitle": "Repeat the color sequence!",
+    "play": "Play",
+    "instructions": "Watch the color sequence and repeat it correctly!",
+    "bestScore": "Best Score",
+    "round": "Round",
+    "score": "Score",
+    "watch": "Watch!",
+    "yourTurn": "Your Turn!",
+    "correct": "Correct!",
+    "wrong": "Wrong!",
+    "getReady": "Get Ready!",
+    "gameOver": {
+      "title": "Game Over",
+      "playAgain": "Play Again",
+      "roundsCompleted": "Rounds Completed",
+      "newRecord": "New Record!"
+    }
+  },
+  "slidingPuzzle": {
+    "home": {
+      "title": "Sliding Puzzle",
+      "subtitle": "Slide tiles to complete the picture!",
+      "chooseDifficulty": "Choose Difficulty",
+      "easy": "Easy",
+      "easyDesc": "3×3 grid",
+      "hard": "Hard",
+      "hardDesc": "4×4 grid",
+      "instructions": "Slide tiles to arrange them in the correct order!",
+      "best": "Best",
+      "moves": "Moves"
+    },
+    "game": {
+      "easy": "Easy",
+      "hard": "Hard",
+      "moves": "Moves",
+      "tile": "Tile",
+      "youWon": "You Won!",
+      "newBest": "New Best!",
+      "coinsEarned": "Coins Earned",
+      "playAgain": "Play Again",
+      "newGame": "New Game",
+      "back": "Back"
+    }
+  },
+  "snackStack": {
+    "home": {
+      "title": "Snack Stack",
+      "subtitle": "Stack snacks without dropping!",
+      "play": "Play",
+      "instructions": "Time your taps to stack snacks as high as possible!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "score": "Score",
+      "height": "Height",
+      "perfect": "Perfect!",
+      "tapToDrop": "Tap to Drop",
+      "toppled": "Toppled!",
+      "playAgain": "Play Again"
+    }
+  },
+  "treasureDig": {
+    "home": {
+      "title": "Treasure Dig",
+      "subtitle": "Dig deep to find hidden treasure!",
+      "play": "Play",
+      "instructions": "Tap the soil to dig and find hidden treasures!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "score": "Score",
+      "found": "Found!",
+      "allFound": "All Found!",
+      "gameOver": "Game Over",
+      "playAgain": "Play Again"
+    }
+  },
+  "weatherWizard": {
+    "home": {
+      "title": "Weather Wizard",
+      "subtitle": "Control the weather with magic!",
+      "play": "Play",
+      "instructions": "Match the weather spells to control nature!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "scene": "Scene",
+      "need": "Need",
+      "choose": "Choose",
+      "complete": "Scene Complete!",
+      "playAgain": "Play Again"
+    }
+  },
+  "whackAMole": {
+    "home": {
+      "title": "Whack a Mole",
+      "subtitle": "Tap the moles before they hide!",
+      "play": "Play!",
+      "instructions": "Tap the moles as they appear. Don't miss!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "score": "Score",
+      "round": "Round",
+      "time": "Time",
+      "combo": "Combo",
+      "accuracy": "Accuracy",
+      "pestsBopped": "Pests Bopped",
+      "finalScore": "Final Score",
+      "gameOver": "Game Over",
+      "newBest": "New Best!",
+      "coinsEarned": "Coins Earned",
+      "playAgain": "Play Again",
+      "back": "Back"
+    }
+  },
+  "wordBubbles": {
+    "home": {
+      "title": "Word Bubbles",
+      "subtitle": "Pop bubbles to spell words!",
+      "play": "Play",
+      "instructions": "Pop the letter bubbles in the right order to spell words!",
+      "bestScore": "Best Score"
+    },
+    "game": {
+      "score": "Score",
+      "correct": "Correct!",
+      "complete": "All Words Found!",
+      "clear": "Clear"
+    }
   }
 }

--- a/app/src/locales/pt-BR.json
+++ b/app/src/locales/pt-BR.json
@@ -265,5 +265,712 @@
   },
   "ads": {
     "notAvailable": "Anúncio não disponível"
+  },
+  "selectGame": {
+    "title": "🎮 Escolha um Jogo",
+    "subtitle": "Escolha sua aventura!",
+    "allGames": "Todos",
+    "sortBy": "Ordenar:",
+    "addFavorite": "Adicionar aos Favoritos",
+    "removeFavorite": "Remover dos Favoritos",
+    "sort": {
+      "default": "Padrão",
+      "name": "Nome",
+      "category": "Categoria",
+      "favorites": "Favoritos"
+    },
+    "categories": {
+      "pet": "Pet",
+      "puzzle": "Puzzle",
+      "adventure": "Aventura",
+      "casual": "Casual"
+    },
+    "petCare": {
+      "name": "Pet Care",
+      "description": "Cuide do seu pet virtual todos os dias!"
+    },
+    "muito": {
+      "name": "Muito",
+      "description": "Combine números para fazer pontos!"
+    },
+    "colorTap": {
+      "name": "Color Tap",
+      "description": "Toque nas cores certas rapidamente!"
+    },
+    "memoryMatch": {
+      "name": "Memory Match",
+      "description": "Encontre todos os pares iguais!"
+    },
+    "petRunner": {
+      "name": "Pet Runner",
+      "description": "Corra, pule e desvie dos obstáculos!"
+    },
+    "simonSays": {
+      "name": "Simon Says",
+      "description": "Repita a sequência de cores!"
+    },
+    "dressUpRelay": {
+      "name": "Dress Up Relay",
+      "description": "Vista seu pet com estilo!"
+    },
+    "colorMixer": {
+      "name": "Color Mixer",
+      "description": "Misture cores para acertar o alvo!"
+    },
+    "feedThePet": {
+      "name": "Feed the Pet",
+      "description": "Pegue a comida que cai para seu pet!"
+    },
+    "whackAMole": {
+      "name": "Whack a Mole",
+      "description": "Toque nas toupeiras antes que se escondam!"
+    },
+    "catchTheBall": {
+      "name": "Catch the Ball",
+      "description": "Pegue as bolas que caem no cesto!"
+    },
+    "slidingPuzzle": {
+      "name": "Sliding Puzzle",
+      "description": "Deslize as peças para completar a imagem!"
+    },
+    "bubblePop": {
+      "name": "Bubble Pop",
+      "description": "Estoure todas as bolhas coloridas!"
+    },
+    "petDanceParty": {
+      "name": "Pet Dance Party",
+      "description": "Dance junto com seu pet!"
+    },
+    "treasureDig": {
+      "name": "Treasure Dig",
+      "description": "Cave fundo para encontrar tesouros!"
+    },
+    "balloonFloat": {
+      "name": "Balloon Float",
+      "description": "Flutue seu balão até o topo!"
+    },
+    "paintSplash": {
+      "name": "Paint Splash",
+      "description": "Crie respingos coloridos de tinta!"
+    },
+    "snackStack": {
+      "name": "Snack Stack",
+      "description": "Empilhe lanches sem deixar cair!"
+    },
+    "lightningTap": {
+      "name": "Lightning Tap",
+      "description": "Toque rápido como um relâmpago!"
+    },
+    "pathFinder": {
+      "name": "Path Finder",
+      "description": "Encontre o caminho até o objetivo!"
+    },
+    "shapeSorter": {
+      "name": "Shape Sorter",
+      "description": "Encaixe as formas nos lugares certos!"
+    },
+    "mirrorMatch": {
+      "name": "Mirror Match",
+      "description": "Espelhe os padrões para vencer!"
+    },
+    "wordBubbles": {
+      "name": "Word Bubbles",
+      "description": "Estoure bolhas para formar palavras!"
+    },
+    "jigsawPets": {
+      "name": "Jigsaw Pets",
+      "description": "Complete o puzzle do pet!"
+    },
+    "connectDots": {
+      "name": "Connect Dots",
+      "description": "Conecte os pontos para revelar a imagem!"
+    },
+    "petExplorer": {
+      "name": "Pet Explorer",
+      "description": "Explore o mundo com seu pet!"
+    },
+    "weatherWizard": {
+      "name": "Weather Wizard",
+      "description": "Controle o clima com magia!"
+    },
+    "petTaxi": {
+      "name": "Pet Taxi",
+      "description": "Dirija seu táxi de pets pela cidade!"
+    },
+    "petChef": {
+      "name": "Pet Chef",
+      "description": "Cozinhe refeições deliciosas para pets!"
+    },
+    "musicMaker": {
+      "name": "Music Maker",
+      "description": "Crie músicas divertidas com seu pet!"
+    },
+    "gardenGrow": {
+      "name": "Garden Grow",
+      "description": "Cultive um lindo jardim!"
+    },
+    "photoStudio": {
+      "name": "Photo Studio",
+      "description": "Tire fotos fofas do seu pet!"
+    }
+  },
+  "balloonFloat": {
+    "home": {
+      "title": "Balloon Float",
+      "subtitle": "Flutue seu balão até o topo!",
+      "play": "Jogar",
+      "instructions": "Toque para fazer seu balão subir. Evite obstáculos!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "score": "Pontuação",
+      "gameOver": "Fim de Jogo",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "bubblePop": {
+    "home": {
+      "title": "Bubble Pop",
+      "subtitle": "Estoure todas as bolhas coloridas!",
+      "play": "Jogar",
+      "instructions": "Toque nas bolhas para estourá-las!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "score": "Pontuação",
+      "combo": "Combo",
+      "finalScore": "Pontuação Final",
+      "gameOver": "Fim de Jogo",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "catchTheBall": {
+    "home": {
+      "title": "Catch the Ball",
+      "subtitle": "Pegue as bolas que caem no cesto!",
+      "play": "Jogar",
+      "instructions": "Mova o cesto para pegar as bolas que caem!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "score": "Pontuação",
+      "caught": "Pegou",
+      "missed": "Perdeu",
+      "lane": "Faixa",
+      "finalScore": "Pontuação Final",
+      "gameOver": "Fim de Jogo",
+      "newBest": "Novo Recorde!",
+      "coinsEarned": "Moedas Ganhas",
+      "ready": "Pronto!",
+      "tapToStart": "Toque para Começar",
+      "playAgain": "Jogar Novamente",
+      "back": "Voltar"
+    }
+  },
+  "colorMixer": {
+    "title": "Color Mixer",
+    "subtitle": "Misture cores para acertar o alvo!",
+    "play": "Jogar",
+    "instructions": "Arraste as amostras de cor para a tigela e acerte a cor alvo!",
+    "levelsCompleted": "Níveis Completos",
+    "totalStars": "Total de Estrelas",
+    "level": "Nível",
+    "levelComplete": "Nível Completo!",
+    "accuracy": "Precisão",
+    "backToLevels": "Voltar aos Níveis",
+    "nextLevel": "Próximo Nível",
+    "tryAgain": "Tentar Novamente",
+    "check": "Verificar",
+    "reset": "Resetar",
+    "target": "Alvo",
+    "yourMix": "Sua Mistura",
+    "dragHere": "Arraste aqui",
+    "mixingBowl": "Tigela de Mistura"
+  },
+  "colorTap": {
+    "title": "Color Tap",
+    "subtitle": "Toque nas cores certas rapidamente!",
+    "play": "Jogar",
+    "instructions": "Toque nos botões coloridos na ordem correta!",
+    "bestScore": "Melhor Pontuação",
+    "gameOver": {
+      "title": "Fim de Jogo",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "connectDots": {
+    "home": {
+      "title": "Connect Dots",
+      "subtitle": "Conecte os pontos para revelar a imagem!",
+      "play": "Jogar",
+      "instructions": "Conecte todos os pontos em ordem para completar a imagem!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "complete": "Completo!",
+      "revealed": "Revelado",
+      "tapNext": "Toque no próximo ponto",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "dressUpRelay": {
+    "title": "Dress Up Relay",
+    "subtitle": "Vista seu pet com estilo!",
+    "play": "Jogar",
+    "instructions": "Memorize a roupa e recrie-a no seu pet!",
+    "bestScore": "Melhor Pontuação",
+    "round": "Rodada",
+    "timeLeft": "Tempo Restante",
+    "memorize": "Memorize a roupa!",
+    "dressYourPet": "Vista seu pet!",
+    "target": "Alvo",
+    "yourOutfit": "Sua Roupa",
+    "correct": "Correto!",
+    "perfect": "Perfeito!",
+    "nextRound": "Próxima Rodada",
+    "gameOver": {
+      "title": "Fim de Jogo",
+      "playAgain": "Jogar Novamente",
+      "roundsCompleted": "Rodadas Completas",
+      "totalScore": "Pontuação Total"
+    }
+  },
+  "feedThePet": {
+    "home": {
+      "title": "Feed the Pet",
+      "subtitle": "Pegue a comida que cai para seu pet!",
+      "play": "Jogar",
+      "instructions": "Mova a tigela para pegar a comida que cai para seu pet faminto!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "score": "Pontuação",
+      "combo": "Combo",
+      "finalScore": "Pontuação Final",
+      "gameOver": "Fim de Jogo",
+      "newBest": "Novo Recorde!",
+      "coinsEarned": "Moedas Ganhas",
+      "playAgain": "Jogar Novamente",
+      "back": "Voltar"
+    }
+  },
+  "gardenGrow": {
+    "home": {
+      "title": "Garden Grow",
+      "subtitle": "Cultive um lindo jardim!",
+      "play": "Jogar",
+      "instructions": "Regue e cuide das plantas para cultivar um jardim incrível!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "title": "Garden Grow",
+      "complete": "Jardim Completo!",
+      "harvested": "Colhido",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "jigsawPets": {
+    "home": {
+      "title": "Jigsaw Pets",
+      "subtitle": "Complete o puzzle do pet!",
+      "play": "Jogar",
+      "instructions": "Arraste as peças do puzzle para completar a imagem do pet!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "title": "Jigsaw Pets",
+      "complete": "Puzzle Completo!",
+      "moves": "Movimentos",
+      "pieces": "Peças",
+      "placing": "Colocando...",
+      "tapCell": "Toque em uma célula",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "lightningTap": {
+    "home": {
+      "title": "Lightning Tap",
+      "subtitle": "Toque rápido como um relâmpago!",
+      "play": "Jogar",
+      "instructions": "Toque nos alvos brilhantes o mais rápido que puder!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "score": "Pontuação",
+      "misses": "Erros",
+      "gameOver": "Fim de Jogo",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "memoryMatch": {
+    "title": "Memory Match",
+    "subtitle": "Encontre todos os pares iguais!",
+    "play": "Jogar",
+    "instructions": "Vire as cartas para encontrar os pares. Lembre-se das posições!",
+    "bestScore": "Melhor Pontuação",
+    "moves": "Movimentos",
+    "matched": "Combinou!",
+    "cardFaceDown": "Carta virada",
+    "gameOver": {
+      "title": "Você Ganhou!",
+      "moves": "Movimentos",
+      "time": "Tempo",
+      "score": "Pontuação",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "mirrorMatch": {
+    "home": {
+      "title": "Mirror Match",
+      "subtitle": "Espelhe os padrões para vencer!",
+      "play": "Jogar",
+      "instructions": "Copie o padrão da esquerda para o lado direito!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "title": "Mirror Match",
+      "pattern": "Padrão",
+      "mirror": "Espelho",
+      "color": "Cor",
+      "check": "Verificar",
+      "perfect": "Perfeito!",
+      "score": "Pontuação"
+    }
+  },
+  "muito": {
+    "title": "Muito",
+    "subtitle": "Combine números para fazer pontos!",
+    "play": "Jogar",
+    "instructions": "Combine o número na tela com a resposta certa!",
+    "bestScore": "Melhor Pontuação",
+    "score": "Pontuação",
+    "answerLabel": "Resposta",
+    "correct": "Correto!",
+    "wrong": "Errado!",
+    "multiplayer": {
+      "title": "Multijogador",
+      "play": "Multijogador",
+      "host": "Criar",
+      "join": "Entrar",
+      "createRoom": "Criar Sala",
+      "joinRoom": "Entrar na Sala",
+      "hostDescription": "Crie uma sala e convide amigos",
+      "joinDescription": "Entre na sala de um amigo",
+      "roomCode": "Código da Sala",
+      "codePlaceholder": "Digite o código da sala...",
+      "lobby": "Saguão",
+      "players": "Jogadores",
+      "waitingForOpponent": "Aguardando oponente...",
+      "waitingForHost": "Aguardando o anfitrião...",
+      "waitingForRound": "Aguardando a próxima rodada...",
+      "start": "Iniciar Jogo",
+      "connecting": "Conectando...",
+      "opponent": "Oponente",
+      "you": "Você",
+      "youWonRound": "Você ganhou essa rodada!",
+      "opponentWonRound": "O oponente ganhou essa rodada!",
+      "tieRound": "Empate!",
+      "resultWin": "Você Ganhou!",
+      "resultLose": "Você Perdeu!",
+      "resultTie": "Empate!",
+      "playAgain": "Jogar Novamente",
+      "backToMenu": "Voltar ao Menu"
+    }
+  },
+  "musicMaker": {
+    "home": {
+      "title": "Music Maker",
+      "subtitle": "Crie músicas divertidas com seu pet!",
+      "play": "Jogar",
+      "instructions": "Toque nos instrumentos para criar sua própria música!",
+      "bestScore": "Músicas Criadas"
+    },
+    "game": {
+      "title": "Music Maker",
+      "save": "Salvar",
+      "clear": "Limpar"
+    }
+  },
+  "paintSplash": {
+    "home": {
+      "title": "Paint Splash",
+      "subtitle": "Crie respingos coloridos de tinta!",
+      "play": "Jogar",
+      "instructions": "Toque na tela para criar respingos coloridos de tinta!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "title": "Paint Splash",
+      "score": "Pontuação",
+      "selectColor": "Selecionar Cor",
+      "complete": "Completo!",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "pathFinder": {
+    "home": {
+      "title": "Path Finder",
+      "subtitle": "Encontre o caminho até o objetivo!",
+      "play": "Jogar",
+      "instructions": "Desenhe um caminho do início ao fim evitando obstáculos!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "title": "Path Finder",
+      "score": "Pontuação",
+      "steps": "Passos",
+      "hint": "Dica",
+      "reset": "Resetar",
+      "pathFound": "Caminho Encontrado!",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "petChef": {
+    "home": {
+      "title": "Pet Chef",
+      "subtitle": "Cozinhe refeições deliciosas para pets!",
+      "play": "Jogar",
+      "instructions": "Siga a receita para cozinhar a refeição perfeita!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "recipe": "Receita",
+      "ingredients": "Ingredientes",
+      "serve": "Servir!",
+      "next": "Próximo",
+      "complete": "Refeição Pronta!",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "petDanceParty": {
+    "home": {
+      "title": "Pet Dance Party",
+      "subtitle": "Dance junto com seu pet!",
+      "play": "Jogar",
+      "instructions": "Siga os passos de dança mostrados na tela!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "finalScore": "Pontuação Final",
+      "gameOver": "Fim de Jogo",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "petExplorer": {
+    "home": {
+      "title": "Pet Explorer",
+      "subtitle": "Explore o mundo com seu pet!",
+      "play": "Jogar",
+      "instructions": "Guie seu pet por locais emocionantes para descobrir tesouros!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "score": "Pontuação",
+      "exploring": "Explorando...",
+      "complete": "Exploração Completa!",
+      "finish": "Finalizar",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "petRunner": {
+    "title": "Pet Runner",
+    "subtitle": "Corra, pule e desvie dos obstáculos!",
+    "play": "Jogar",
+    "instructions": "Toque para pular sobre obstáculos e corra o mais longe que puder!",
+    "bestScore": "Melhor Pontuação",
+    "tapToStart": "Toque para Começar",
+    "gameOver": {
+      "title": "Fim de Jogo",
+      "score": "Pontuação",
+      "distance": "Distância",
+      "coins": "Moedas",
+      "newBest": "Novo Recorde!",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "petTaxi": {
+    "home": {
+      "title": "Pet Taxi",
+      "subtitle": "Dirija seu táxi de pets pela cidade!",
+      "play": "Jogar",
+      "instructions": "Pegue passageiros e leve-os aos seus destinos!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "deliver": "Entregar",
+      "delivered": "Entregue!",
+      "gameOver": "Fim de Jogo",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "photoStudio": {
+    "home": {
+      "title": "Photo Studio",
+      "subtitle": "Tire fotos fofas do seu pet!",
+      "play": "Jogar",
+      "instructions": "Escolha poses, acessórios e fundos para a foto perfeita do pet!",
+      "bestScore": "Fotos Tiradas"
+    },
+    "game": {
+      "title": "Photo Studio",
+      "background": "Fundo",
+      "pose": "Pose",
+      "props": "Acessórios",
+      "stickers": "Figurinhas",
+      "gallery": "Galeria",
+      "takePhoto": "Tirar Foto!"
+    }
+  },
+  "shapeSorter": {
+    "home": {
+      "title": "Shape Sorter",
+      "subtitle": "Encaixe as formas nos lugares certos!",
+      "play": "Jogar",
+      "instructions": "Arraste as formas para seus encaixes o mais rápido que puder!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "score": "Pontuação",
+      "round": "Rodada",
+      "shapes": "Formas",
+      "holes": "Encaixes",
+      "selected": "Selecionado",
+      "tapHole": "Toque em um encaixe",
+      "complete": "Rodada Completa!",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "simonSays": {
+    "title": "Simon Says",
+    "subtitle": "Repita a sequência de cores!",
+    "play": "Jogar",
+    "instructions": "Observe a sequência de cores e repita corretamente!",
+    "bestScore": "Melhor Pontuação",
+    "round": "Rodada",
+    "score": "Pontuação",
+    "watch": "Observe!",
+    "yourTurn": "Sua Vez!",
+    "correct": "Correto!",
+    "wrong": "Errado!",
+    "getReady": "Prepare-se!",
+    "gameOver": {
+      "title": "Fim de Jogo",
+      "playAgain": "Jogar Novamente",
+      "roundsCompleted": "Rodadas Completas",
+      "newRecord": "Novo Recorde!"
+    }
+  },
+  "slidingPuzzle": {
+    "home": {
+      "title": "Sliding Puzzle",
+      "subtitle": "Deslize as peças para completar a imagem!",
+      "chooseDifficulty": "Escolha a Dificuldade",
+      "easy": "Fácil",
+      "easyDesc": "Grade 3×3",
+      "hard": "Difícil",
+      "hardDesc": "Grade 4×4",
+      "instructions": "Deslize as peças para organizá-las na ordem correta!",
+      "best": "Melhor",
+      "moves": "Movimentos"
+    },
+    "game": {
+      "easy": "Fácil",
+      "hard": "Difícil",
+      "moves": "Movimentos",
+      "tile": "Peça",
+      "youWon": "Você Ganhou!",
+      "newBest": "Novo Recorde!",
+      "coinsEarned": "Moedas Ganhas",
+      "playAgain": "Jogar Novamente",
+      "newGame": "Novo Jogo",
+      "back": "Voltar"
+    }
+  },
+  "snackStack": {
+    "home": {
+      "title": "Snack Stack",
+      "subtitle": "Empilhe lanches sem deixar cair!",
+      "play": "Jogar",
+      "instructions": "Calcule o tempo dos toques para empilhar lanches o mais alto possível!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "score": "Pontuação",
+      "height": "Altura",
+      "perfect": "Perfeito!",
+      "tapToDrop": "Toque para Soltar",
+      "toppled": "Caiu!",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "treasureDig": {
+    "home": {
+      "title": "Treasure Dig",
+      "subtitle": "Cave fundo para encontrar tesouros!",
+      "play": "Jogar",
+      "instructions": "Toque no solo para cavar e encontrar tesouros escondidos!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "score": "Pontuação",
+      "found": "Encontrado!",
+      "allFound": "Todos Encontrados!",
+      "gameOver": "Fim de Jogo",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "weatherWizard": {
+    "home": {
+      "title": "Weather Wizard",
+      "subtitle": "Controle o clima com magia!",
+      "play": "Jogar",
+      "instructions": "Combine os feitiços do clima para controlar a natureza!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "scene": "Cena",
+      "need": "Necessário",
+      "choose": "Escolher",
+      "complete": "Cena Completa!",
+      "playAgain": "Jogar Novamente"
+    }
+  },
+  "whackAMole": {
+    "home": {
+      "title": "Whack a Mole",
+      "subtitle": "Toque nas toupeiras antes que se escondam!",
+      "play": "Jogar!",
+      "instructions": "Toque nas toupeiras quando aparecerem. Não erre!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "score": "Pontuação",
+      "round": "Rodada",
+      "time": "Tempo",
+      "combo": "Combo",
+      "accuracy": "Precisão",
+      "pestsBopped": "Toupeiras Acertadas",
+      "finalScore": "Pontuação Final",
+      "gameOver": "Fim de Jogo",
+      "newBest": "Novo Recorde!",
+      "coinsEarned": "Moedas Ganhas",
+      "playAgain": "Jogar Novamente",
+      "back": "Voltar"
+    }
+  },
+  "wordBubbles": {
+    "home": {
+      "title": "Word Bubbles",
+      "subtitle": "Estoure bolhas para formar palavras!",
+      "play": "Jogar",
+      "instructions": "Estoure as bolhas com letras na ordem certa para formar palavras!",
+      "bestScore": "Melhor Pontuação"
+    },
+    "game": {
+      "score": "Pontuação",
+      "correct": "Correto!",
+      "complete": "Todas as Palavras Encontradas!",
+      "clear": "Limpar"
+    }
   }
 }


### PR DESCRIPTION
## Summary
This PR adds comprehensive localization strings for a game selection interface and 28 individual mini-games across English and Brazilian Portuguese locales.

## Key Changes
- **Game Selection UI**: Added `selectGame` section with:
  - Main UI labels (title, subtitle, sorting options)
  - Category definitions (pet, puzzle, adventure, casual)
  - Game listings with names and descriptions for all 28 games

- **Game-Specific Localization**: Added dedicated locale sections for each game:
  - `balloonFloat`, `bubblePop`, `catchTheBall`, `colorMixer`, `colorTap`
  - `connectDots`, `dressUpRelay`, `feedThePet`, `gardenGrow`, `jigsawPets`
  - `lightningTap`, `memoryMatch`, `mirrorMatch`, `muito`, `musicMaker`
  - `paintSplash`, `pathFinder`, `petChef`, `petDanceParty`, `petExplorer`
  - `petRunner`, `petTaxi`, `photoStudio`, `shapeSorter`, `simonSays`
  - `slidingPuzzle`, `snackStack`, `treasureDig`, `weatherWizard`, `whackAMole`, `wordBubbles`

- **Game UI Strings**: Each game includes localized strings for:
  - Home/menu screens (title, subtitle, instructions, best score)
  - In-game UI (score, game over, play again, etc.)
  - Game-specific mechanics (e.g., "combo" for bubble pop, "moves" for puzzles, "multiplayer" for Muito)

- **Locales Updated**:
  - `pt-BR.json`: Brazilian Portuguese translations
  - `en.json`: English translations (already had selectGame, now adding game-specific sections)

## Implementation Details
- Strings follow consistent naming patterns across games for maintainability
- Each game has a `home` section for pre-game UI and a `game` section for in-game UI
- Special cases like `muito` include a `multiplayer` subsection with room/lobby terminology
- Descriptions are concise and game-mechanic focused

https://claude.ai/code/session_01GB4yxfaSeApZH4PkxGAh2u