### PR TITLE
Refactor Color Tap game state management with refs and progressive difficulty

### DIFF
--- a/app/src/artifacts/color-tap.tsx
+++ b/app/src/artifacts/color-tap.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 
 /**
  * Color Tap - Example Claude AI Artifact
@@ -45,6 +45,10 @@ const ColorTapGame: React.FC = () => {
   const [gameOver, setGameOver] = useState(false);
   const [timeLeft, setTimeLeft] = useState(100);
 
+  const scoreRef = useRef(0);
+  const livesRef = useRef(3);
+  const gameOverRef = useRef(false);
+
   const pickNewRound = useCallback(() => {
     const target = COLORS[Math.floor(Math.random() * COLORS.length)];
     const others = COLORS.filter((c) => c.name !== target.name);
@@ -55,7 +59,17 @@ const ColorTapGame: React.FC = () => {
     setTimeLeft(100);
   }, []);
 
+  const endGame = useCallback(() => {
+    if (gameOverRef.current) return;
+    gameOverRef.current = true;
+    setGameOver(true);
+    if (window.RNBridge) window.RNBridge.gameOver(scoreRef.current);
+  }, []);
+
   const startGame = () => {
+    scoreRef.current = 0;
+    livesRef.current = 3;
+    gameOverRef.current = false;
     setScore(0);
     setLives(3);
     setGameOver(false);
@@ -70,39 +84,41 @@ const ColorTapGame: React.FC = () => {
     const timer = setInterval(() => {
       setTimeLeft((prev) => {
         if (prev <= 0) {
-          setLives((l) => {
-            const newLives = l - 1;
-            if (newLives <= 0) {
-              setGameOver(true);
-              if (window.RNBridge) window.RNBridge.gameOver(score);
-            }
-            return newLives;
-          });
-          pickNewRound();
+          const newLives = livesRef.current - 1;
+          livesRef.current = newLives;
+          setLives(newLives);
+          if (newLives <= 0) {
+            endGame();
+          } else {
+            pickNewRound();
+          }
           return 100;
         }
-        return prev - 2;
+        // Speed increases every 50 points (max 5x faster)
+        const decrement = Math.min(10, 2 + Math.floor(scoreRef.current / 50));
+        return Math.max(0, prev - decrement);
       });
     }, 100);
 
     return () => clearInterval(timer);
-  }, [gameStarted, gameOver, pickNewRound, score]);
+  }, [gameStarted, gameOver, pickNewRound, endGame]);
 
   const handleTap = (color: ColorOption) => {
-    if (gameOver) return;
+    if (gameOverRef.current) return;
 
     if (color.name === targetColor.name) {
-      const newScore = score + 10;
+      const newScore = scoreRef.current + 10;
+      scoreRef.current = newScore;
       setScore(newScore);
       setFeedback('Correct!');
       if (window.RNBridge) window.RNBridge.sendScore(newScore);
     } else {
-      setFeedback('Wrong!');
-      const newLives = lives - 1;
+      const newLives = livesRef.current - 1;
+      livesRef.current = newLives;
       setLives(newLives);
+      setFeedback('Wrong!');
       if (newLives <= 0) {
-        setGameOver(true);
-        if (window.RNBridge) window.RNBridge.gameOver(score);
+        endGame();
         return;
       }
     }

--- a/app/src/screens/ColorTapGameScreen.tsx
+++ b/app/src/screens/ColorTapGameScreen.tsx
@@ -50,8 +50,10 @@ const ARTIFACT_HTML = `<!DOCTYPE html>
 </head>
 <body>
   <div id="root"></div>
-  <script type="text/babel">
-    const { useState, useEffect, useCallback, useRef, useMemo, useReducer, useContext, createContext } = React;
+  <script type="text/babel" data-presets="react,typescript">
+    const { useState, useEffect, useCallback, useRef } = React;
+
+    interface ColorOption { name: string; hex: string; }
 
     /**
  * Color Tap - Example Claude AI Artifact
@@ -94,6 +96,10 @@ const ColorTapGame = () => {
   const [gameOver, setGameOver] = useState(false);
   const [timeLeft, setTimeLeft] = useState(100);
 
+  const scoreRef = useRef(0);
+  const livesRef = useRef(3);
+  const gameOverRef = useRef(false);
+
   const pickNewRound = useCallback(() => {
     const target = COLORS[Math.floor(Math.random() * COLORS.length)];
     const others = COLORS.filter((c) => c.name !== target.name);
@@ -104,7 +110,17 @@ const ColorTapGame = () => {
     setTimeLeft(100);
   }, []);
 
+  const endGame = useCallback(() => {
+    if (gameOverRef.current) return;
+    gameOverRef.current = true;
+    setGameOver(true);
+    if (window.RNBridge) window.RNBridge.gameOver(scoreRef.current);
+  }, []);
+
   const startGame = () => {
+    scoreRef.current = 0;
+    livesRef.current = 3;
+    gameOverRef.current = false;
     setScore(0);
     setLives(3);
     setGameOver(false);
@@ -119,39 +135,41 @@ const ColorTapGame = () => {
     const timer = setInterval(() => {
       setTimeLeft((prev) => {
         if (prev <= 0) {
-          setLives((l) => {
-            const newLives = l - 1;
-            if (newLives <= 0) {
-              setGameOver(true);
-              if (window.RNBridge) window.RNBridge.gameOver(score);
-            }
-            return newLives;
-          });
-          pickNewRound();
+          const newLives = livesRef.current - 1;
+          livesRef.current = newLives;
+          setLives(newLives);
+          if (newLives <= 0) {
+            endGame();
+          } else {
+            pickNewRound();
+          }
           return 100;
         }
-        return prev - 2;
+        // Speed increases every 50 points (max 5x faster)
+        const decrement = Math.min(10, 2 + Math.floor(scoreRef.current / 50));
+        return Math.max(0, prev - decrement);
       });
     }, 100);
 
     return () => clearInterval(timer);
-  }, [gameStarted, gameOver, pickNewRound, score]);
+  }, [gameStarted, gameOver, pickNewRound, endGame]);
 
   const handleTap = (color: ColorOption) => {
-    if (gameOver) return;
+    if (gameOverRef.current) return;
 
     if (color.name === targetColor.name) {
-      const newScore = score + 10;
+      const newScore = scoreRef.current + 10;
+      scoreRef.current = newScore;
       setScore(newScore);
       setFeedback('Correct!');
       if (window.RNBridge) window.RNBridge.sendScore(newScore);
     } else {
-      setFeedback('Wrong!');
-      const newLives = lives - 1;
+      const newLives = livesRef.current - 1;
+      livesRef.current = newLives;
       setLives(newLives);
+      setFeedback('Wrong!');
       if (newLives <= 0) {
-        setGameOver(true);
-        if (window.RNBridge) window.RNBridge.gameOver(score);
+        endGame();
         return;
       }
     }
@@ -226,7 +244,6 @@ const ColorTapGame = () => {
   );
 };
 
-ColorTapGame;
 
     const root = ReactDOM.createRoot(document.getElementById('root'));
     root.render(React.createElement(ColorTapGame));


### PR DESCRIPTION
## Summary
Refactored the Color Tap game to use React refs for critical game state and implemented progressive difficulty scaling. This improves state consistency and adds dynamic gameplay that increases in speed as the player scores more points.

## Key Changes
- **State management refactoring**: Introduced `useRef` hooks (`scoreRef`, `livesRef`, `gameOverRef`) to track game state that needs immediate consistency, preventing stale closures in timer callbacks
- **Progressive difficulty**: Timer decrement now scales with score (increases by 1 every 50 points, capped at 5x faster), making the game progressively more challenging
- **Game over logic consolidation**: Created `endGame()` callback to centralize game-over handling and prevent duplicate state updates
- **Improved timer logic**: Simplified the timer callback by using refs instead of state setters, eliminating nested state update callbacks
- **Code cleanup**: Removed unused React hooks from imports and cleaned up unnecessary code patterns

## Implementation Details
- Refs are used for `score`, `lives`, and `gameOver` state to ensure timer and event handlers always access current values without dependency array issues
- State setters (`setScore`, `setLives`, `setGameOver`) are still called for UI updates, but logic now relies on refs for consistency
- The `endGame()` callback includes a guard (`gameOverRef.current`) to prevent multiple game-over triggers
- Timer speed formula: `Math.min(10, 2 + Math.floor(scoreRef.current / 50))` creates smooth difficulty progression
- Changes applied consistently to both the artifact HTML version and the standalone TypeScript component

https://claude.ai/code/session_01M3SDpEbxRtvP681jQ8sXW6