### PR TITLE
fix(wardrobe): show correct emoji icon for each clothing item

### DIFF
--- a/app/src/data/clothingItems.ts
+++ b/app/src/data/clothingItems.ts
@@ -3,28 +3,29 @@ import { ImageSourcePropType } from 'react-native';
 
 type ClothingItemWithAsset = ClothingItem & {
   asset: ImageSourcePropType | null;
+  emoji: string;
 };
 
 // Substitua `asset: null` por require real quando adicionar os PNGs.
 export const CLOTHING_ITEMS: ClothingItemWithAsset[] = [
   // Head
-  { id: 'hat_red', slot: 'head', assetKey: 'hat_red', name: 'Chapéu Vermelho', asset: null },
-  { id: 'hat_blue', slot: 'head', assetKey: 'hat_blue', name: 'Chapéu Azul', asset: null },
-  { id: 'crown', slot: 'head', assetKey: 'crown', name: 'Coroa', asset: null },
+  { id: 'hat_red', slot: 'head', assetKey: 'hat_red', name: 'Chapéu Vermelho', asset: null, emoji: '🎩' },
+  { id: 'hat_blue', slot: 'head', assetKey: 'hat_blue', name: 'Chapéu Azul', asset: null, emoji: '🪖' },
+  { id: 'crown', slot: 'head', assetKey: 'crown', name: 'Coroa', asset: null, emoji: '👑' },
 
   // Eyes
-  { id: 'eyes_big', slot: 'eyes', assetKey: 'eyes_big', name: 'Olhos Grandes', asset: null },
-  { id: 'eyes_star', slot: 'eyes', assetKey: 'eyes_star', name: 'Olhos Estrela', asset: null },
-  { id: 'glasses', slot: 'eyes', assetKey: 'glasses', name: 'Óculos', asset: null },
+  { id: 'eyes_big', slot: 'eyes', assetKey: 'eyes_big', name: 'Olhos Grandes', asset: null, emoji: '👁️' },
+  { id: 'eyes_star', slot: 'eyes', assetKey: 'eyes_star', name: 'Olhos Estrela', asset: null, emoji: '⭐' },
+  { id: 'glasses', slot: 'eyes', assetKey: 'glasses', name: 'Óculos', asset: null, emoji: '👓' },
 
   // Torso
-  { id: 'shirt_blue', slot: 'torso', assetKey: 'shirt_blue', name: 'Camiseta Azul', asset: null },
-  { id: 'shirt_red', slot: 'torso', assetKey: 'shirt_red', name: 'Camiseta Vermelha', asset: null },
-  { id: 'dress_pink', slot: 'torso', assetKey: 'dress_pink', name: 'Vestido Rosa', asset: null },
+  { id: 'shirt_blue', slot: 'torso', assetKey: 'shirt_blue', name: 'Camiseta Azul', asset: null, emoji: '👕' },
+  { id: 'shirt_red', slot: 'torso', assetKey: 'shirt_red', name: 'Camiseta Vermelha', asset: null, emoji: '👘' },
+  { id: 'dress_pink', slot: 'torso', assetKey: 'dress_pink', name: 'Vestido Rosa', asset: null, emoji: '👗' },
 
   // Paws
-  { id: 'paws_boots', slot: 'paws', assetKey: 'paws_boots', name: 'Botas', asset: null },
-  { id: 'paws_socks', slot: 'paws', assetKey: 'paws_socks', name: 'Meias', asset: null },
+  { id: 'paws_boots', slot: 'paws', assetKey: 'paws_boots', name: 'Botas', asset: null, emoji: '👢' },
+  { id: 'paws_socks', slot: 'paws', assetKey: 'paws_socks', name: 'Meias', asset: null, emoji: '🧦' },
 ];
 
 export const getItemsBySlot = (slot: ClothingSlot): ClothingItemWithAsset[] => {

--- a/app/src/screens/WardrobeScene.tsx
+++ b/app/src/screens/WardrobeScene.tsx
@@ -141,7 +141,7 @@ export const WardrobeScene: React.FC<Props> = ({ navigation }) => {
             >
               <View style={[styles.itemPreview, { width: spacing(40), height: spacing(40) }]}>
                 <Text style={[styles.itemPlaceholder, { fontSize: wardrobeSizes.itemEmoji }]}>
-                  👔
+                  {item.emoji}
                 </Text>
               </View>
               <Text style={[styles.itemName, { fontSize: wardrobeSizes.itemName }]}>


### PR DESCRIPTION
Every item in the wardrobe grid was displaying the same hardcoded 👔 emoji. Added an `emoji` field to each clothing item in clothingItems.ts and updated WardrobeScene to render that field instead of the placeholder.

https://claude.ai/code/session_01FLwUp4SZC5tf7Ahdsi5h8Q