### PR TITLE
fix: use srcdoc instead of blob URL for emulator iframe to fix ROM lo…

### DIFF
--- a/app/src/screens/GbaEmulatorGameScreen.tsx
+++ b/app/src/screens/GbaEmulatorGameScreen.tsx
@@ -36,9 +36,9 @@ const buildEmulatorHtml = (romBlobUrl: string, title: string): string => `<!DOCT
 </body>
 </html>`;
 
-const useEmulatorUri = (romId: string | null, romBlob: Blob | null, title: string): string | null => {
+const useEmulatorHtml = (romId: string | null, romBlob: Blob | null, title: string): string | null => {
   const [emulatorResource, setEmulatorResource] = useState<{
-    htmlUrl: string;
+    html: string;
     romId: string;
     title: string;
   } | null>(null);
@@ -56,15 +56,12 @@ const useEmulatorUri = (romId: string | null, romBlob: Blob | null, title: strin
 
     const romUrl = URL.createObjectURL(romBlob);
     const html = buildEmulatorHtml(romUrl, title);
-    const htmlBlob = new Blob([html], { type: 'text/html' });
-    const htmlUrl = URL.createObjectURL(htmlBlob);
 
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setEmulatorResource({ htmlUrl, romId, title });
+    setEmulatorResource({ html, romId, title });
 
     return () => {
       URL.revokeObjectURL(romUrl);
-      URL.revokeObjectURL(htmlUrl);
     };
   }, [romBlob, romId, supportsObjectUrls, title]);
 
@@ -77,7 +74,7 @@ const useEmulatorUri = (romId: string | null, romBlob: Blob | null, title: strin
     return null;
   }
 
-  return emulatorResource.htmlUrl;
+  return emulatorResource.html;
 };
 
 export const GbaEmulatorGameScreen: React.FC<Props> = ({ navigation }) => {
@@ -87,9 +84,9 @@ export const GbaEmulatorGameScreen: React.FC<Props> = ({ navigation }) => {
 
   const selectedRom = recentRoms.find((r) => r.id === selectedRomId) ?? null;
   const romBlob = selectedRomId ? getRomBlob(selectedRomId) : null;
-  const emulatorUri = useEmulatorUri(selectedRomId, romBlob, selectedRom?.title ?? 'GBA ROM');
+  const emulatorHtml = useEmulatorHtml(selectedRomId, romBlob, selectedRom?.title ?? 'GBA ROM');
 
-  if (emulatorUri) {
+  if (emulatorHtml) {
     return (
       <SafeAreaView style={styles.container}>
         <View style={styles.header}>
@@ -102,7 +99,7 @@ export const GbaEmulatorGameScreen: React.FC<Props> = ({ navigation }) => {
         {Platform.OS === 'web' ? (
           <View style={styles.emulatorView} testID="gba-emulator-webview">
             <iframe
-              src={emulatorUri}
+              srcdoc={emulatorHtml}
               style={{ flex: 1, border: 'none', width: '100%', height: '100%' } as never}
               allow="autoplay"
               title={selectedRom?.title ?? 'GBA Emulator'}
@@ -110,7 +107,7 @@ export const GbaEmulatorGameScreen: React.FC<Props> = ({ navigation }) => {
           </View>
         ) : (
           <WebView
-            source={{ uri: emulatorUri }}
+            source={{ html: emulatorHtml }}
             style={styles.emulatorView}
             allowsInlineMediaPlayback
             mediaPlaybackRequiresUserAction={false}

--- a/app/src/screens/__tests__/GbaEmulatorShell.test.tsx
+++ b/app/src/screens/__tests__/GbaEmulatorShell.test.tsx
@@ -181,10 +181,7 @@ describe('GbaEmulator shell screens', () => {
     try {
       Object.defineProperty(Platform, 'OS', { configurable: true, value: 'web' });
 
-      const createObjectURL = jest
-        .fn()
-        .mockReturnValueOnce('blob:rom')
-        .mockReturnValueOnce('blob:html');
+      const createObjectURL = jest.fn().mockReturnValueOnce('blob:rom');
       const revokeObjectURL = jest.fn();
 
       global.URL = {
@@ -208,12 +205,12 @@ describe('GbaEmulator shell screens', () => {
       const { getByTestId, unmount } = render(<GbaEmulatorGameScreen navigation={navigation} />);
 
       expect(getByTestId('gba-emulator-webview')).toBeTruthy();
-      expect(createObjectURL).toHaveBeenCalledTimes(2);
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
 
       unmount();
 
       expect(revokeObjectURL).toHaveBeenCalledWith('blob:rom');
-      expect(revokeObjectURL).toHaveBeenCalledWith('blob:html');
+      expect(revokeObjectURL).toHaveBeenCalledTimes(1);
     } finally {
       Object.defineProperty(Platform, 'OS', { configurable: true, value: originalPlatform });
       global.URL = originalUrl;


### PR DESCRIPTION
…ading

When the emulator iframe was loaded from a blob: URL, EmulatorJS (loaded from an external CDN) could not reliably fetch the ROM via its blob: URL in certain browser environments, causing a black screen on load.

Switching the iframe to use the srcdoc attribute embeds the HTML content directly, so the iframe inherits the parent document's origin and can access the ROM blob URL without restriction. The HTML blob URL creation is removed entirely; only the ROM blob URL is created and cleaned up.

https://claude.ai/code/session_01H3wDgUBypw3AH2wNrHPVqq